### PR TITLE
feat(atom): add input

### DIFF
--- a/src/components/atoms/Button.jsx
+++ b/src/components/atoms/Button.jsx
@@ -1,44 +1,40 @@
-import React from 'react';
-import styles from '../../styles/components/atoms/Button.module.css';
+import styles from "../../styles/components/atoms/Button.module.css";
 
 /**
- * Variants: 'action' | 'chip' | 'control'
+ * Variants: 'action' | 'control'
  * Sizes:
  *  - action: 'xl'(600x55), 'lg'(312x55), 'md'(140x55), 'cancel'(288x55), 'study-mobile'(106x35), 'more'(288x55)
- *  - chip: 'chip'(400x55)
  *  - control (rect): 'ctrl-lg'(333x60), 'ctrl-sm'(140x45)
  *  - control (circle): 'circle-lg'(64x64), 'circle-sm'(48x48)
  *
- * Examples:
- * <Button variant="action" size="xl">오늘의 습관으로 가기</Button>
- * <Button variant="action" size="md">확인</Button>
- * <Button variant="action" size="cancel">취소</Button>
- * <Button variant="chip" size="chip" selected>더보기</Button>
- * <Button variant="control" size="ctrl-lg">Stop</Button>
- * <Button variant="control" size="circle-lg" shape="circle" aria-label="Pause">Ⅱ</Button>
+ * Notes:
+ * - 기본 type은 "button"입니다. 필요한 경우 type을 명시적으로 지정하세요.
+ * - onClick, aria-*, disabled 등 표준 HTMLButtonElement 속성은 `...props`를 통해 그대로 전달됩니다.
  */
-
 export default function Button({
   children,
-  variant = 'action',
-  size = 'md',
-  fullWidth = false,
+  variant = "action",
+  size = "md",
+  shape = "rect",         // 'rect' | 'circle' (control일 때 사용)
+  type = "button",        // 안전한 기본값 복원
   disabled = false,
-  className = '',
+  fullWidth = false,
+  className = "",
   ...props
 }) {
-  const cls = [
-    styles.btn,
-    styles[variant],
-    styles[`size-${size}`],
-    fullWidth ? styles.fullWidth : '',
+  const classes = [
+    styles.button,
+    variant === "action" ? styles.action : styles.control,
+    fullWidth ? styles.fullWidth : "",
+    shape === "circle" ? styles.circle : "",
+    size ? styles[`size-${size}`] : "",
     className,
   ]
     .filter(Boolean)
-    .join(' ');
+    .join(" ");
 
   return (
-    <button className={cls} disabled={disabled} {...props}>
+    <button {...props} type={type} className={classes} disabled={disabled}>
       {children}
     </button>
   );

--- a/src/components/atoms/Input.jsx
+++ b/src/components/atoms/Input.jsx
@@ -1,36 +1,44 @@
-import styles from "./Input.module.css";
+import { forwardRef } from "react";
+import styles from "../../styles/components/atoms/Input.module.css";
 
 /**
- * Pure Input atom — 라벨/헬퍼/에러 문구 없이, 시각 상태만.
- * - invalid: 테두리 빨강 
+ * Pure Input atom — 라벨/헬퍼/에러 문구 없이 시각 상태만.
+ * - invalid: 테두리만 빨강
  * - rightSlot: 아이콘/버튼(예: 비밀번호 토글) 붙일 때 사용
+ * - forwardRef 지원 (포커스 제어 등)
  */
-export default function Input({
-  value,
-  onChange,
-  type = "text",
-  placeholder,
-  disabled = false,
-  invalid = false,
-  rightSlot = null,
-  className = "",
-  ...rest
-}) {
+const Input = forwardRef(function Input(
+  {
+    value,
+    onChange,
+    type = "text",
+    placeholder,
+    disabled = false,
+    invalid = false,
+    rightSlot = null,
+    className = "",
+    ...rest
+  },
+  ref,
+) {
   const hasRight = !!rightSlot;
 
   return (
     <div className={`${styles.wrap} ${hasRight ? styles.hasRight : ""} ${className}`}>
       <input
         className={`${styles.input} ${invalid ? styles.invalid : ""}`}
-        value={value}
-        onChange={onChange}
+        {...(value !== undefined ? { value } : {})}
+        {...(onChange ? { onChange } : {})}
         type={type}
         placeholder={placeholder}
         disabled={disabled}
         aria-invalid={invalid || undefined}
+        ref={ref}
         {...rest}
       />
       {hasRight ? <div className={styles.rightSlot}>{rightSlot}</div> : null}
     </div>
   );
-}
+});
+
+export default Input;

--- a/src/components/atoms/Toast.jsx
+++ b/src/components/atoms/Toast.jsx
@@ -1,46 +1,33 @@
 import styles from "../../styles/components/atoms/Toast.module.css";
 
-const ALLOWED_TYPES = ['error', 'mismatch', 'point'];
-
-/**
- * Toast 컴포넌트
- * @param {Object} props
- * @param {'error'|'mismatch'|'point'} [props.type='error'] - 알림 유형
- * @param {number} [props.point=0] - point 알림일 경우 표시할 값
- * @param {string} [props.message] - 기본 문구 대신 외부에서 전달할 문구
- * @param {string} [props.className] - 추가 className
- */
 export default function Toast({
-  type = 'error',
-  point = 0,
+  type = "info",           // 'info' | 'success' | 'error' | 'point'
+  role = "status",
   message,
-  className = '',
+  className = "",
   ...props
 }) {
+  const allowed = new Set(["info", "success", "error", "point"]);
+  const safeType = allowed.has(type) ? type : "info";
   const messageMap = {
-    error: '집중이 중단되었습니다.',
-    mismatch: '비밀번호가 일치하지 않습니다. 다시 입력해주세요.',
-    point: `${point}포인트를 획득했습니다!`,
+    info: "알림",
+    success: "완료",
+    error: "에러",
+    point: "포인트",
   };
-
-  const iconMap = {
-    error: '🚨',
-    mismatch: '🚨',
-    point: '🎉',
-  };
-
-  const safeType = ALLOWED_TYPES.includes(type) ? type : 'error';
-  const role = safeType === 'point' ? 'status' : 'alert'; // role이 aria-live 내포
 
   return (
     <div
-      {...props} // 외부 aria-*가 내부 a11y를 덮지 않도록 먼저 펼침
       className={`${styles.toast} ${styles[safeType]} ${className}`}
       role={role}
       aria-atomic={true}
+      {...props}
     >
-      <span aria-hidden="true">{iconMap[safeType]}</span>
-      <span className={styles.text}>{message ?? messageMap[safeType]}</span>
+      <span className={styles.text}>
+        {typeof message === "string" && message.trim().length > 0
+          ? message
+          : messageMap[safeType]}
+      </span>
     </div>
   );
 }

--- a/src/styles/components/atoms/Button.module.css
+++ b/src/styles/components/atoms/Button.module.css
@@ -1,86 +1,45 @@
-.btn {
-  font-weight: 600; /* Pretendard SemiBold */
-  border-radius: 1rem; /* 10px */
-  border: none;
+.button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.8rem; /* 8px */
+  gap: 0.8rem;
+  padding: 0 1.6rem;
+  border: none;
+  border-radius: 0.8rem;
   cursor: pointer;
   user-select: none;
   white-space: nowrap;
-  padding: 0 1.6rem; /* 16px */
-  background: var(--brand-blue);
-  color: #fff;
-  transition:
-    transform 120ms ease,
-    background-color 120ms ease,
-    color 120ms ease,
-    border-color 120ms ease,
-    box-shadow 120ms ease;
+  transition: transform 120ms ease, background-color 120ms ease, color 120ms ease, box-shadow 120ms ease;
 }
+.button:active { transform: translateY(1px); }
+.button:disabled { background: var(--btn-inactive); color: #fff; cursor: not-allowed; opacity: .8; }
 
-.btn:active { transform: translateY(0.1rem); } /* 1px */
+/* Variant: action — 폰트 18px */
+.action { background: var(--brand-blue); color: #fff; font-size: 1.8rem; }
 
-.btn:disabled {
-  background: var(--btn-inactive);
-  color: #fff;
-  cursor: not-allowed;
-  opacity: 0.9;
-}
+/* Variant: control (아이콘/원형 등) */
+.control { background: var(--background-neutral, #eee); color: var(--text-primary, #111827); }
 
-/* Variant */
-.action {
-  background: var(--brand-blue);
-  color: #fff;
-}
-.action:hover:not(:disabled) {
-  background: var(--brand-blue-dark);
-}
+/* 원형 버튼용 */
+.circle { border-radius: 9999px; padding: 0; }
 
-.control {
-  background: var(--btn-active);
-  color: #fff;
-}
-.control:hover:not(:disabled) {
-  box-shadow: 0 0.2rem 1rem rgba(0, 19, 167, 0.18); /* 0 2px 10px */
-}
+/* Full width */
+.fullWidth { width: 100%; }
 
-/* 원형 컨트롤 */
-.size-circle-lg,
-.size-circle-sm {
-  border-radius: 50%;
-  padding: 0; /* 안쪽 여백 제거 */
-}
-
-/* Sizes */
-.size-xl { width: 60rem; height: 5.5rem; }       /* 600x55 */
-.size-lg { width: 31.2rem; height: 5.5rem; }     /* 312x55 */
-.size-md { width: 14rem; height: 5.5rem; }       /* 140x55 */
+/* ===== Sizes (action) ===== */
+.size-xl { width: 60rem;  height: 5.5rem; }   /* 600x55 */
+.size-lg { width: 31.2rem; height: 5.5rem; }  /* 312x55 */
+.size-md { width: 14rem;  height: 5.5rem; }   /* 140x55 */
 .size-cancel { width: 28.8rem; height: 5.5rem; } /* 288x55 */
 .size-study-mobile { width: 10.6rem; height: 3.5rem; } /* 106x35 */
-.size-more { width: 28.8rem; height: 5.5rem; }   /* 288x55 */
+.size-more { width: 28.8rem; height: 5.5rem; } /* 288x55 */
 
-.size-chip { width: 40rem; height: 5.5rem; }     /* 400x55 */
+/* ===== Sizes (control, rect) ===== */
+.size-ctrl-lg { width: 33.3rem; height: 6rem; font-size: 2.8rem; } /* 333x60, 28px */
+.size-ctrl-sm { width: 14rem;  height: 4.5rem; }                    /* 140x45 */
 
-.size-ctrl-lg { width: 33.3rem; height: 6rem; }  /* 333x60 */
-.size-ctrl-sm { width: 14rem; height: 4.5rem; }  /* 140x45 */
+/* ===== Sizes (control, circle) ===== */
+.size-circle-lg { width: 6.4rem; height: 6.4rem; }  /* 64x64 */
+.size-circle-sm { width: 4.8rem; height: 4.8rem; }  /* 48x48 */
 
-.size-circle-lg { width: 6.4rem; height: 6.4rem; } /* 64x64 */
-.size-circle-sm { width: 4.8rem; height: 4.8rem; } /* 48x48 */
-
-.fullWidth { width: 100% !important; }
-
-/* Action 그룹 버튼 폰트 */
-.action {
-  background: var(--brand-blue);
-  color: #fff;
-  font-size: 1.8rem; /* 18px */
-}
-
-/* Control 그룹 버튼 */
-.size-ctrl-lg {
-  width: 33.3rem;   /* 333px */
-  height: 6rem;     /* 60px */
-  font-size: 2.8rem; /* 28px */
-}
+/* 중복/잔존 규칙 정리: .action/.size-ctrl-lg 중복 제거, .size-chip 삭제 */

--- a/src/styles/components/atoms/Input.module.css
+++ b/src/styles/components/atoms/Input.module.css
@@ -6,23 +6,29 @@
 .input {
   width: 100%;
   height: 44px;
-  border: 1px solid var(--background-neutral);
+  border: 1px solid var(--background-neutral, #e5e7eb);
   border-radius: 8px;
   padding: 0 12px;
   font-size: 16px;
   line-height: 1.2;
-  background: var(--background-secondary);
-  color: var(--text-primary);
+  background: var(--background-secondary, #fff);
+  color: var(--text-primary, #111827);
   outline: 0;
   transition: border-color 120ms ease, box-shadow 120ms ease, background-color 120ms ease;
 }
 
 .input::placeholder {
-  color: var(--text-gray);
+  color: var(--text-gray, #6b7280);
 }
 
 .input:focus {
-  border-color: var(--brand-blue);
+  border-color: var(--brand-blue, #0013a7);
+  box-shadow: 0 0 0 2px rgba(0, 19, 167, 0.12);
+}
+
+/* Keyboard-only focus ring */
+.input:focus-visible {
+  border-color: var(--brand-blue, #0013a7);
   box-shadow: 0 0 0 2px rgba(0, 19, 167, 0.12);
 }
 
@@ -33,14 +39,12 @@
 }
 
 .input.invalid {
-  border-color: var(--warning-red);
+  border-color: var(--warning-red, #dc2626);
   box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.08);
 }
 
-/* 오른쪽 아이콘/버튼이 있을 때 입력 텍스트가 겹치지 않도록 여백 확보 */
-.hasRight .input {
-  padding-right: 44px;
-}
+/* 오른쪽 아이콘/버튼이 있을 때 입력 텍스트 겹침 방지 */
+.hasRight .input { padding-right: 44px; }
 
 .rightSlot {
   position: absolute;

--- a/src/styles/components/atoms/Toast.module.css
+++ b/src/styles/components/atoms/Toast.module.css
@@ -5,25 +5,22 @@
   gap: 0.8rem;
   padding: 1.4rem 2.8rem;
   border-radius: 0.5rem;
-  font-size: 1.6rem; /* 16px 기준 */
+  font-size: 1.6rem;   /* 16px 기준 */
   font-weight: 500;
   line-height: 1.6;
+  /* 긴 메시지 대응 (CodeRabbit 제안 반영) */
+  max-width: min(90vw, 32rem);
+  width: max-content;
 }
 
 .text {
-  white-space: nowrap;
-  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.error,
-.mismatch {
-  background: var(--toast-error-bg, rgba(253, 224, 233, 0.5));
-  color: var(--warning-red, #dc2626);
-}
-
-.point {
-  background: var(--toast-point-bg, rgba(189, 204, 236, 0.5));
-  color: var(--brand-blue, #0013a7);
-}
+/* Variants */
+.info    { background: #edf2ff; color: #1e3a8a; }
+.success { background: #e8f5e8; color: #166534; }
+.error   { background: var(--warning-light, #fee2e2); color: var(--warning-dark, #b91c1c); }
+.point   { background: #e8f8f5; color: #0a3394; }


### PR DESCRIPTION
### 반영 브랜치
feat/input-component → develop

### 변경 사항
- [x] Input Atom 컴포넌트 제작 (Input.jsx, Input.module.css, index.js)
- [x] invalid 상태, disabled 상태, placeholder, rightSlot(아이콘 버튼) 지원 추가

### 테스트 결과
- placeholder 정상 표시 확인
- focus 시 brand-blue 테두리 적용 확인
- invalid 상태일 때 warning-red 테두리 적용 확인
- disabled 상태일 때 회색 배경 처리 및 입력 불가 확인

### 참고 사항 (Optional)
- Input은 순수 Atom으로만 제작 (라벨, 에러 문구 제외)
- Label, Helper, Error 문구는 Molecule 단계(LabelInput)에서 관리 예정
- CSS 변수(variables.css) 기반 색상 토큰 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 새로운 Input 컴포넌트 추가: forwardRef 지원, invalid 상태/오른쪽 슬롯(rightSlot) 제공, 접근성(aria-invalid) 반영.
- 리팩터
  - Button API 간소화: 일반 버튼 속성 전달 방식 통일, chip 변형 제거, 원형은 shape="circle"로 지정.
  - Toast API 조정: 기본 유형 info, role/message 속성 추가, point 제거, 아이콘 제거, 메시지 표시 로직 단순화.
- 스타일
  - Button 스타일 전면 개편: .btn→.button, rem 기반 사이즈 재정의, circle 반경 확대, hover/전이 효과 조정, fullWidth 개선.
  - Toast 스타일 개선: info/success 추가, mismatch 제거, 색상 재조정, 너비 max-content, 텍스트 오버플로우 처리 유지.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->