### PR TITLE
feat(chip): add variant="add" + inline edit + editing border

### DIFF
--- a/src/components/atoms/Chip.jsx
+++ b/src/components/atoms/Chip.jsx
@@ -1,0 +1,93 @@
+import { forwardRef, useEffect, useRef } from "react";
+import styles from "../../styles/components/atoms/Chip.module.css";
+
+/**
+ * Chip (40rem x 5.5rem, 10px = 1rem)
+ *
+ * props:
+ * - label: string
+ * - variant: 'neutral' | 'add'
+ *   - neutral: 일반 칩
+ *   - add    : 추가용 칩(＋만 표시, 항상 비선택 톤)
+ * - selected: boolean      (선택 시 브랜드 블루 배경)
+ * - editing : boolean      (편집 중일 때 1px 브랜드 블루 테두리 + input 표시)
+ * - disabled: boolean
+ *
+ * - onClick(): void        칩 클릭(선택/편집 진입 트리거)
+ * - onChange(value): void  편집 중 입력 변경
+ * - onConfirm(): void      Enter/blur 저장
+ * - onCancel(): void       Esc 취소
+ */
+const Chip = forwardRef(function Chip(
+  {
+    label = "",
+    variant = "neutral",   // 'neutral' | 'add'
+    selected = false,
+    editing = false,
+    disabled = false,
+    onClick,
+    onChange,
+    onConfirm,
+    onCancel,
+    className = "",
+    ...rest
+  },
+  ref
+) {
+  const inputRef = useRef(null);
+
+  // 편집 모드 진입 시 자동 포커스 & 전체 선택
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  const isAdd = variant === "add";
+  // add 변형은 항상 비선택 톤, neutral은 selected에 따라 톤 결정
+  const toneClass = !isAdd && selected ? styles.selected : styles.unselected;
+
+  return (
+    <button
+      type="button"
+      ref={ref}
+      className={[
+        styles.chip,
+        toneClass,
+        editing ? styles.editing : "",
+        disabled ? styles.disabled : "",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      onClick={disabled ? undefined : onClick}
+      aria-pressed={!isAdd ? selected : undefined}
+      aria-disabled={disabled || undefined}
+      disabled={disabled}
+      {...rest}
+    >
+      {isAdd ? (
+        <span className={styles.addSign}>＋</span>
+      ) : editing ? (
+        <input
+          ref={inputRef}
+          className={styles.editorInput}
+          defaultValue={label}
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") onConfirm?.(e);
+            if (e.key === "Escape") onCancel?.(e);
+          }}
+          onChange={(e) => onChange?.(e.target.value)}
+          onBlur={(e) => onConfirm?.(e)}
+          aria-label="칩 라벨 편집"
+        />
+      ) : (
+        <span className={styles.label}>{label}</span>
+      )}
+    </button>
+  );
+});
+
+export default Chip;

--- a/src/components/atoms/Chip.jsx
+++ b/src/components/atoms/Chip.jsx
@@ -10,13 +10,17 @@ import styles from "../../styles/components/atoms/Chip.module.css";
  *   - neutral: 일반 칩
  *   - add    : 추가용 칩(＋만 표시, 항상 비선택 톤)
  * - selected: boolean      (선택 시 브랜드 블루 배경)
- * - editing : boolean      (편집 중일 때 1px 브랜드 블루 테두리 + input 표시)
+ * - editing : boolean      (편집 중이면 1px 브랜드 블루 테두리 + input 표시)
  * - disabled: boolean
  *
- * - onClick(): void        칩 클릭(선택/편집 진입 트리거)
- * - onChange(value): void  편집 중 입력 변경
- * - onConfirm(): void      Enter/blur 저장
- * - onCancel(): void       Esc 취소
+ * - onClick(): void                  칩 클릭(선택/편집 진입 트리거)
+ * - onChange(value: string): void    편집 중 입력 변경
+ * - onConfirm(e, value: string): void  Enter/blur 저장
+ * - onCancel(e): void                Esc 취소
+ *
+ * 접근성:
+ * - neutral 변형: aria-pressed 로 토글 표현(단일선택 그룹이면 radiogroup 사용 고려)
+ * - add 변형: 시각용 ＋는 aria-hidden, 버튼에는 aria-label="새 칩 추가"
  */
 const Chip = forwardRef(function Chip(
   {
@@ -35,6 +39,7 @@ const Chip = forwardRef(function Chip(
   ref
 ) {
   const inputRef = useRef(null);
+  const ignoreNextBlurRef = useRef(false);
 
   // 편집 모드 진입 시 자동 포커스 & 전체 선택
   useEffect(() => {
@@ -58,17 +63,16 @@ const Chip = forwardRef(function Chip(
         editing ? styles.editing : "",
         disabled ? styles.disabled : "",
         className,
-      ]
-        .filter(Boolean)
-        .join(" ")}
+      ].filter(Boolean).join(" ")}
       onClick={disabled ? undefined : onClick}
+      {...rest}                                {/* 외부 props 먼저 병합 */}
       aria-pressed={!isAdd ? selected : undefined}
       aria-disabled={disabled || undefined}
+      aria-label={isAdd ? "새 칩 추가" : rest?.["aria-label"]} /* add는 접근성 라벨 강제 */
       disabled={disabled}
-      {...rest}
     >
       {isAdd ? (
-        <span className={styles.addSign}>＋</span>
+        <span className={styles.addSign} aria-hidden="true">＋</span>
       ) : editing ? (
         <input
           ref={inputRef}
@@ -76,11 +80,23 @@ const Chip = forwardRef(function Chip(
           defaultValue={label}
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => {
-            if (e.key === "Enter") onConfirm?.(e);
-            if (e.key === "Escape") onCancel?.(e);
+            if (e.key === "Enter") {
+              e.preventDefault();
+              onConfirm?.(e, e.currentTarget.value);
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              ignoreNextBlurRef.current = true; // 직후 blur 무시
+              onCancel?.(e);
+            }
           }}
           onChange={(e) => onChange?.(e.target.value)}
-          onBlur={(e) => onConfirm?.(e)}
+          onBlur={(e) => {
+            if (ignoreNextBlurRef.current) {
+              ignoreNextBlurRef.current = false;
+              return;
+            }
+            onConfirm?.(e, e.currentTarget.value);
+          }}
           aria-label="칩 라벨 편집"
         />
       ) : (

--- a/src/components/atoms/Chip.jsx
+++ b/src/components/atoms/Chip.jsx
@@ -2,30 +2,17 @@ import { forwardRef, useEffect, useRef } from "react";
 import styles from "../../styles/components/atoms/Chip.module.css";
 
 /**
- * Chip (40rem x 5.5rem, 10px = 1rem)
- *
- * props:
- * - label: string
+ * Chip Atom
  * - variant: 'neutral' | 'add'
- *   - neutral: 일반 칩
- *   - add    : 추가용 칩(＋만 표시, 항상 비선택 톤)
- * - selected: boolean      (선택 시 브랜드 블루 배경)
- * - editing : boolean      (편집 중이면 1px 브랜드 블루 테두리 + input 표시)
+ * - selected: boolean
+ * - editing: boolean
  * - disabled: boolean
- *
- * - onClick(): void                  칩 클릭(선택/편집 진입 트리거)
- * - onChange(value: string): void    편집 중 입력 변경
- * - onConfirm(e, value: string): void  Enter/blur 저장
- * - onCancel(e): void                Esc 취소
- *
- * 접근성:
- * - neutral 변형: aria-pressed 로 토글 표현(단일선택 그룹이면 radiogroup 사용 고려)
- * - add 변형: 시각용 ＋는 aria-hidden, 버튼에는 aria-label="새 칩 추가"
+ * - onClick, onChange, onConfirm(e, value), onCancel(e)
  */
 const Chip = forwardRef(function Chip(
   {
     label = "",
-    variant = "neutral",   // 'neutral' | 'add'
+    variant = "neutral",
     selected = false,
     editing = false,
     disabled = false,
@@ -41,7 +28,6 @@ const Chip = forwardRef(function Chip(
   const inputRef = useRef(null);
   const ignoreNextBlurRef = useRef(false);
 
-  // 편집 모드 진입 시 자동 포커스 & 전체 선택
   useEffect(() => {
     if (editing && inputRef.current) {
       inputRef.current.focus();
@@ -50,7 +36,6 @@ const Chip = forwardRef(function Chip(
   }, [editing]);
 
   const isAdd = variant === "add";
-  // add 변형은 항상 비선택 톤, neutral은 selected에 따라 톤 결정
   const toneClass = !isAdd && selected ? styles.selected : styles.unselected;
 
   return (
@@ -65,10 +50,10 @@ const Chip = forwardRef(function Chip(
         className,
       ].filter(Boolean).join(" ")}
       onClick={disabled ? undefined : onClick}
-      {...rest}                                {/* 외부 props 먼저 병합 */}
+      {...rest}
       aria-pressed={!isAdd ? selected : undefined}
       aria-disabled={disabled || undefined}
-      aria-label={isAdd ? "새 칩 추가" : rest?.["aria-label"]} /* add는 접근성 라벨 강제 */
+      aria-label={isAdd ? "새 칩 추가" : undefined}
       disabled={disabled}
     >
       {isAdd ? (
@@ -85,7 +70,7 @@ const Chip = forwardRef(function Chip(
               onConfirm?.(e, e.currentTarget.value);
             } else if (e.key === "Escape") {
               e.preventDefault();
-              ignoreNextBlurRef.current = true; // 직후 blur 무시
+              ignoreNextBlurRef.current = true;
               onCancel?.(e);
             }
           }}

--- a/src/pages/TestPage.jsx
+++ b/src/pages/TestPage.jsx
@@ -1,22 +1,86 @@
-import EmojiCounter from '../components/molecules/EmojiCounter';
+import React, { useState } from "react";
+import EmojiCounter from "../components/molecules/EmojiCounter";
+import Chip from "../components/atoms/Chip.jsx";
 
 export default function TestPage() {
+  // ---- 기존 EmojiCounter 테스트 ----
   const emojiData = [
-    {
-      id: 1,
-      emoji: '👍',
-      count: 1,
-    },
-    {
-      id: 2,
-      emoji: '❤️',
-      count: 1,
-    },
+    { id: 1, emoji: "👍", count: 1 },
+    { id: 2, emoji: "❤️", count: 1 },
   ];
 
+  // ---- Chip 테스트용 상태 ----
+  const [chips, setChips] = useState([
+    { id: "1", label: "미라클모닝 6시 기상", selected: false },
+    { id: "2", label: "운동 30분", selected: false },
+  ]);
+  const [editingId, setEditingId] = useState(null);
+  const [draft, setDraft] = useState("");
+
+  const startEdit = (id) => {
+    const cur = chips.find((c) => c.id === id);
+    setEditingId(id);
+    setDraft(cur ? cur.label : "");
+    setChips((prev) =>
+      prev.map((c) => ({ ...c, selected: c.id === id }))
+    );
+  };
+
+  const confirmEdit = () => {
+    if (!editingId) return;
+    const text = (draft || "").trim();
+    setChips((prev) =>
+      prev.map((c) =>
+        c.id === editingId ? { ...c, label: text || c.label } : c
+      )
+    );
+    setEditingId(null);
+    setDraft("");
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setDraft("");
+  };
+
+  const addChip = () => {
+    const id = `id_${Date.now()}`;
+    setEditingId(id);
+    setDraft("새 습관");
+    setChips((prev) => [
+      ...prev.map((c) => ({ ...c, selected: false })),
+      { id, label: "새 습관", selected: true },
+    ]);
+  };
+
   return (
-    <div>
-      <EmojiCounter emojiData={emojiData} />
+    <div style={{ display: "grid", gap: "2rem", padding: "1.6rem" }}>
+      {/* 기존 EmojiCounter */}
+      <section>
+        <h2>EmojiCounter Test</h2>
+        <EmojiCounter emojiData={emojiData} />
+      </section>
+
+      {/* 새로운 Chip 샌드박스 */}
+      <section>
+        <h2>Chip Test</h2>
+        <div style={{ display: "grid", gap: "0.8rem" }}>
+          {chips.map((c) => (
+            <Chip
+              key={c.id}
+              label={c.label}
+              selected={c.selected}
+              editing={editingId === c.id}
+              onClick={() => startEdit(c.id)}
+              onChange={(v) => setDraft(v)}
+              onConfirm={confirmEdit}
+              onCancel={cancelEdit}
+            />
+          ))}
+          {/* 추가용 칩 */}
+          <Chip variant="add" onClick={addChip} />
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/pages/TestPage.jsx
+++ b/src/pages/TestPage.jsx
@@ -3,13 +3,13 @@ import EmojiCounter from "../components/molecules/EmojiCounter";
 import Chip from "../components/atoms/Chip.jsx";
 
 export default function TestPage() {
-  // ---- 기존 EmojiCounter 테스트 ----
+  // EmojiCounter 테스트
   const emojiData = [
     { id: 1, emoji: "👍", count: 1 },
     { id: 2, emoji: "❤️", count: 1 },
   ];
 
-  // ---- Chip 테스트용 상태 ----
+  // Chip 테스트 상태
   const [chips, setChips] = useState([
     { id: "1", label: "미라클모닝 6시 기상", selected: false },
     { id: "2", label: "운동 30분", selected: false },
@@ -21,14 +21,12 @@ export default function TestPage() {
     const cur = chips.find((c) => c.id === id);
     setEditingId(id);
     setDraft(cur ? cur.label : "");
-    setChips((prev) =>
-      prev.map((c) => ({ ...c, selected: c.id === id }))
-    );
+    setChips((prev) => prev.map((c) => ({ ...c, selected: c.id === id })));
   };
 
-  const confirmEdit = () => {
+  const confirmEdit = (nextLabel) => {
     if (!editingId) return;
-    const text = (draft || "").trim();
+    const text = (nextLabel ?? draft ?? "").trim();
     setChips((prev) =>
       prev.map((c) =>
         c.id === editingId ? { ...c, label: text || c.label } : c
@@ -44,7 +42,10 @@ export default function TestPage() {
   };
 
   const addChip = () => {
-    const id = `id_${Date.now()}`;
+    const id =
+      typeof crypto !== "undefined" && crypto.randomUUID
+        ? crypto.randomUUID()
+        : `id_${Date.now()}`;
     setEditingId(id);
     setDraft("새 습관");
     setChips((prev) => [
@@ -55,13 +56,11 @@ export default function TestPage() {
 
   return (
     <div style={{ display: "grid", gap: "2rem", padding: "1.6rem" }}>
-      {/* 기존 EmojiCounter */}
       <section>
         <h2>EmojiCounter Test</h2>
         <EmojiCounter emojiData={emojiData} />
       </section>
 
-      {/* 새로운 Chip 샌드박스 */}
       <section>
         <h2>Chip Test</h2>
         <div style={{ display: "grid", gap: "0.8rem" }}>
@@ -73,12 +72,11 @@ export default function TestPage() {
               editing={editingId === c.id}
               onClick={() => startEdit(c.id)}
               onChange={(v) => setDraft(v)}
-              onConfirm={confirmEdit}
+              onConfirm={(_, v) => confirmEdit(v)}
               onCancel={cancelEdit}
             />
           ))}
-          {/* 추가용 칩 */}
-          <Chip variant="add" onClick={addChip} />
+          <Chip variant="add" onClick={addChip} aria-label="새 칩 추가" />
         </div>
       </section>
     </div>

--- a/src/styles/components/atoms/Chip.module.css
+++ b/src/styles/components/atoms/Chip.module.css
@@ -1,11 +1,10 @@
-/* 10px = 1rem 기준 */
 .chip {
   display: inline-flex;
   align-items: center;
   justify-content: center;
 
-  width: 40rem;          /* 기본 PC: 400px */
-  height: 5.5rem;        /* 55px 고정 */
+  width: 40rem;          /* 400px */
+  height: 5.5rem;        /* 55px */
   padding: 0 1.6rem;
   border-radius: 1rem;
   box-sizing: border-box;
@@ -27,24 +26,20 @@
 @media (max-width: 480px) {
   .chip {
     width: 25.6rem; /* 256px */
-    height: 5.5rem; /* 55px 동일 */
+    height: 5.5rem;
   }
 }
 
-
-/* 비선택 톤 */
 .unselected {
   background: var(--background-neutral, #EEE);
   color: var(--text-gray, #818181);
 }
 
-/* 선택 톤 */
 .selected {
   background: var(--brand-blue, #3b82f6);
   color: var(--background-secondary, #FFF);
 }
 
-/* 편집 중이면 1px(=0.1rem) 브랜드 블루 테두리 */
 .editing {
   border: 0.1rem solid var(--brand-blue, #3b82f6);
 }
@@ -56,7 +51,6 @@
   outline-offset: 0.2rem;
 }
 
-/* 라벨 */
 .label {
   font-size: 1.6rem;
   white-space: nowrap;
@@ -64,7 +58,6 @@
   text-overflow: ellipsis;
 }
 
-/* 인라인 에디터 (색은 상위 상속) */
 .editorInput {
   width: 100%;
   height: 100%;
@@ -76,8 +69,7 @@
   color: inherit;
 }
 
-/* variant="add" 표시 */
 .addSign {
-  font-size: 2rem; /* 보기 좋은 + 크기 */
+  font-size: 2rem;
   line-height: 1;
 }

--- a/src/styles/components/atoms/Chip.module.css
+++ b/src/styles/components/atoms/Chip.module.css
@@ -4,13 +4,14 @@
   align-items: center;
   justify-content: center;
 
-  width: 40rem;          /* 400px */
-  height: 5.5rem;        /* 55px */
-  padding: 0 1.6rem;     /* 16px */
-  border-radius: 1rem;   /* 10px */
+  width: 40rem;          /* 기본 PC: 400px */
+  height: 5.5rem;        /* 55px 고정 */
+  padding: 0 1.6rem;
+  border-radius: 1rem;
+  box-sizing: border-box;
 
-  border: none;          /* 기본은 테두리 없음 */
-  font-size: 1.6rem;     /* 16px */
+  border: none;
+  font-size: 1.6rem;
   line-height: 1;
   cursor: pointer;
   user-select: none;
@@ -18,8 +19,18 @@
     background-color .15s ease,
     color .15s ease,
     opacity .15s ease,
-    border-color .15s ease;
+    border-color .15s ease,
+    outline-color .15s ease;
 }
+
+/* 모바일 대응 */
+@media (max-width: 480px) {
+  .chip {
+    width: 25.6rem; /* 256px */
+    height: 5.5rem; /* 55px 동일 */
+  }
+}
+
 
 /* 비선택 톤 */
 .unselected {
@@ -29,19 +40,19 @@
 
 /* 선택 톤 */
 .selected {
-  background: var(--brand-blue);
+  background: var(--brand-blue, #3b82f6);
   color: var(--background-secondary, #FFF);
 }
 
 /* 편집 중이면 1px(=0.1rem) 브랜드 블루 테두리 */
 .editing {
-  border: 0.1rem solid var(--brand-blue);
+  border: 0.1rem solid var(--brand-blue, #3b82f6);
 }
 
 .disabled { opacity: .5; cursor: not-allowed; }
 
 .chip:focus-visible {
-  outline: 0.2rem solid var(--brand-blue);
+  outline: 0.2rem solid var(--brand-blue, #3b82f6);
   outline-offset: 0.2rem;
 }
 

--- a/src/styles/components/atoms/Chip.module.css
+++ b/src/styles/components/atoms/Chip.module.css
@@ -1,0 +1,72 @@
+/* 10px = 1rem 기준 */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 40rem;          /* 400px */
+  height: 5.5rem;        /* 55px */
+  padding: 0 1.6rem;     /* 16px */
+  border-radius: 1rem;   /* 10px */
+
+  border: none;          /* 기본은 테두리 없음 */
+  font-size: 1.6rem;     /* 16px */
+  line-height: 1;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background-color .15s ease,
+    color .15s ease,
+    opacity .15s ease,
+    border-color .15s ease;
+}
+
+/* 비선택 톤 */
+.unselected {
+  background: var(--background-neutral, #EEE);
+  color: var(--text-gray, #818181);
+}
+
+/* 선택 톤 */
+.selected {
+  background: var(--brand-blue);
+  color: var(--background-secondary, #FFF);
+}
+
+/* 편집 중이면 1px(=0.1rem) 브랜드 블루 테두리 */
+.editing {
+  border: 0.1rem solid var(--brand-blue);
+}
+
+.disabled { opacity: .5; cursor: not-allowed; }
+
+.chip:focus-visible {
+  outline: 0.2rem solid var(--brand-blue);
+  outline-offset: 0.2rem;
+}
+
+/* 라벨 */
+.label {
+  font-size: 1.6rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* 인라인 에디터 (색은 상위 상속) */
+.editorInput {
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  text-align: center;
+  font: inherit;
+  color: inherit;
+}
+
+/* variant="add" 표시 */
+.addSign {
+  font-size: 2rem; /* 보기 좋은 + 크기 */
+  line-height: 1;
+}


### PR DESCRIPTION
## 반영 브랜치
- `feat/chip-inline-edit` → `dev`

## 변경 사항
- Chip 리뉴얼
  - 크기 40rem × 5.5rem, radius 1rem 적용
  - 비선택: `background: var(--background-neutral, #EEE)`, `color: var(--text-gray, #818181)`
  - 선택: `background: var(--brand-blue)`, `color: var(--background-secondary, #FFF)`
- variant="add" 도입
  - 라벨 대신 ＋ 표시, 항상 비선택 톤
  - 클릭 시 새 칩 추가 플로우용
- 인라인 편집 지원
  - 칩 클릭 → 선택 + 편집 진입
  - Enter/blur 저장, ESC 취소
  - 편집 중 1px(=0.1rem) 브랜드 블루 테두리 표시
- 삭제(X) 버튼은 Chip 외부(모달)로 분리 예정

## 테스트 결과
- `/test` 페이지에서 다음 시나리오 확인
  - 칩 목록 렌더/선택 색상 전환 정상
  - 칩 클릭 시 편집 진입 및 포커스 자동 이동
  - Enter/blur 저장, ESC 취소 동작 정상
  - 하단 `variant="add"` 칩 클릭 시 새 칩 생성 후 즉시 편집 진입

## 변경 파일
- `src/components/atoms/Chip.jsx` (신규/개편)
- `src/styles/components/atoms/Chip.module.css` (신규)
- `src/pages/TestPage.jsx` (Chip 테스트 섹션 추가, 기존 EmojiCounter 유지)

Test Clip
https://github.com/user-attachments/assets/335256f5-1047-4674-870d-89383e8e164f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * Chip 컴포넌트 추가: 선택/비선택, 편집 모드, 비활성화, 자동 포커스·텍스트 선택 지원.
  * 키보드/보조기술 접근성 개선: Enter 확정, Esc 취소(다음 blur 무시), aria 속성 지원.
  * “추가” 변형으로 새 칩 생성 버튼 제공 및 테스트 페이지에 칩 목록·선택·편집·추가 흐름 연동.

* 스타일
  * 칩 전용 스타일 추가: 선택/비선택 상태, 편집 테두리, 비활성화, 포커스 가시성, 라벨 말줄임 및 입력창/플러스 표시 조정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->