### PR TITLE
feat: dayjs 라이브러리 추가 및 카드 컴포넌트 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.11.0",
+        "dayjs": "^1.11.18",
         "emoji-picker-react": "^4.13.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -2069,6 +2070,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
+      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "axios": "^1.11.0",
+    "dayjs": "^1.11.18",
     "emoji-picker-react": "^4.13.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/src/components/atoms/Text.jsx
+++ b/src/components/atoms/Text.jsx
@@ -1,11 +1,33 @@
-// Text.jsx
+/*
+사용 가이드 (Text 컴포넌트용)
+
+크기 클래스 → font-size
+- text-xs   → 1.0rem (10px)
+- text-sm   → 1.2rem (12px)
+- text-md   → 1.4rem (14px)
+- text-base → 1.6rem (16px)
+- text-lg   → 1.8rem (18px)
+- text-xl   → 2.0rem (20px)
+- text-2xl  → 2.4rem (24px)
+- text-3xl  → 3.2rem (32px)
+
+두께 클래스 → font-weight
+- text-light   → 300
+- text-regular → 400
+- text-medium  → 500
+- text-bold    → 700
+
+예시
+- <Text size="md" weight="regular">기본 텍스트</Text>
+- <Text size="xl" weight="bold" color="#222">굵은 큰 텍스트</Text>
+*/
 import React from 'react';
 import '../../styles/components/atoms/Text.module.css';
 
 function Text({
   size = 'md',
   weight = 'normal',
-  color = 'var(--text-basic, #000)',
+  color = '',
   tag: Tag = 'p',
   children,
 }) {

--- a/src/components/organisms/Card.jsx
+++ b/src/components/organisms/Card.jsx
@@ -3,6 +3,8 @@ import Tag from '../atoms/Tag';
 import Text from '../atoms/Text';
 import Emoji from '../atoms/Emoji';
 import { CARD_PRESETS } from '../../utils/constants/cardPresets';
+import dayjs from 'dayjs';
+import { useEffect, useState } from 'react';
 
 /**
  * Card 컴포넌트
@@ -13,6 +15,7 @@ import { CARD_PRESETS } from '../../utils/constants/cardPresets';
  * @param {string} props.textColor - 커스텀 텍스트 색상
  * @param {number} props.overlayOpacity - 오버레이 투명도 (0-1)
  * @param {number} props.points - 획득 포인트 (기본값: 310)
+ * @param {string} props.nickname - 유저 닉네임
  * @param {string} props.title - 카드 제목
  * @param {string} props.subtitle - 카드 부제목
  * @param {string} props.description - 카드 설명
@@ -25,16 +28,16 @@ export default function Card({
   preset,
   backgroundImage,
   backgroundColor,
-  textColor,
   overlayOpacity,
-  points = 310,
+  nick,
+  points = 5,
   title = '이우더의 UX 스터디',
-  subtitle = '62일째 진행 중',
+  createdAt = '62',
   description = 'Slow And Steady Wins The Race!!',
   emojiData = [
-    { emoji: '👍', count: 37 },
-    { emoji: '🔥', count: 26 },
-    { emoji: '❤️', count: 14 },
+    { emoji: '👍', count: 1 },
+    { emoji: '🔥', count: 3 },
+    { emoji: '❤️', count: 5 },
   ],
   onClick,
   isSelected = false,
@@ -44,7 +47,7 @@ export default function Card({
 
   const finalBackgroundImage = backgroundImage || presetData?.backgroundImage;
   const finalBackgroundColor = backgroundColor || presetData?.backgroundColor;
-  const finalTextColor = textColor || presetData?.textColor || '#FFFFFF';
+
   const finalOverlayOpacity =
     overlayOpacity !== undefined
       ? overlayOpacity
@@ -75,6 +78,16 @@ export default function Card({
     }
   };
 
+  const [daysPassed, setDaysPassed] = useState(createdAt);
+  const calculateDaysPassed = createdAt => {
+    const today = dayjs();
+    const createdDate = dayjs(createdAt);
+    setDaysPassed(today.diff(createdDate, 'day'));
+  };
+  useEffect(() => {
+    calculateDaysPassed('2025-09-01');
+  }, [createdAt]);
+
   return (
     <div
       className={`${styles.card} ${isSelected ? styles.selected : ''}`}
@@ -88,17 +101,32 @@ export default function Card({
 
       <div className={styles.cardContent}>
         <div className={styles.tagSection}>
+          <Text
+            size="lg"
+            weight="bold"
+            color={presetData?.titleTextColor}
+            tag="h3"
+          >
+            <b>{nick}</b>의 {title}
+          </Text>
           <Tag points={points} size="sm" />
         </div>
 
         <div className={styles.textSection}>
-          <Text size="lg" weight="bold" color={finalTextColor} as="h3">
-            {title}
+          <Text
+            size="sm"
+            weight="normal"
+            color={presetData?.dayTextColor}
+            tag="p"
+          >
+            {`${daysPassed}일째 진행 중`}
           </Text>
-          <Text size="sm" weight="normal" color={finalTextColor} as="p">
-            {subtitle}
-          </Text>
-          <Text size="md" weight="normal" color={finalTextColor} as="p">
+          <Text
+            size="md"
+            weight="normal"
+            color={presetData?.descriptionTextColor}
+            tag="p"
+          >
             {description}
           </Text>
         </div>

--- a/src/pages/StudyPage.jsx
+++ b/src/pages/StudyPage.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import styles from '../styles/pages/StudyPage.module.css';
 import { studyApi } from '../utils/api/study/getStudyApi';
 import Card from '../components/organisms/Card';
-import { CARD_PRESETS } from '../utils/constants/cardPresets';
+import Dropdown from '../components/atoms/Dropdown';
 
 export function StudyPage() {
   const [studyList, setStudyList] = useState([]);
@@ -17,19 +17,41 @@ export function StudyPage() {
   }, []);
 
   return (
-    <main className={styles.studyPage}>
-      <h1 className={styles.studyPageTitle}>스터디 둘러보기</h1>
-      <div className={styles.studyList}>
-        {studyList.map(study => (
-          <Card
-            key={study.id}
-            preset={'SOLID_GREEN'}
-            title={study.name}
-            subtitle={study.createdAt.split('T')[0]}
-            description={study.content}
-          />
-        ))}
-      </div>
+    <main className={styles.studyPageContainer}>
+      <section className={styles.studyPageWrapper}>
+        <h1 className={styles.studyPageTitle}>최근 조회한 스터디</h1>
+        <div className={styles.studyList}>
+          {studyList.map(study => (
+            <Card
+              key={study.id}
+              preset={'SOLID_BLUE'}
+              nick={study.nick}
+              title={study.name}
+              createdAt={study.createdAt.split('T')[0]}
+              description={study.content}
+            />
+          ))}
+        </div>
+      </section>
+      <section className={styles.studyPageWrapper}>
+        <h1 className={styles.studyPageTitle}>스터디 둘러보기</h1>
+        <div className={styles.studyListFilter}>
+          <input type="text" />
+          <Dropdown />
+        </div>
+        <div className={styles.studyList}>
+          {studyList.map(study => (
+            <Card
+              key={study.id}
+              preset={'SOLID_BLUE'}
+              nick={study.nick}
+              title={study.name}
+              createdAt={study.createdAt.split('T')[0]}
+              description={study.content}
+            />
+          ))}
+        </div>
+      </section>
     </main>
   );
 }

--- a/src/styles/common.css
+++ b/src/styles/common.css
@@ -24,7 +24,7 @@
   --border-gray: #ddd;
 
   /* 카드 색상 */
-  --card-blue: #ebf2ff;
+  --card-blue: #e8f4ff;
   --card-green: #e8f5e8;
   --card-mintblue: #e8f8f5;
   --card-ocean: #ebf2ff;

--- a/src/styles/components/atoms/Dropdown.module.css
+++ b/src/styles/components/atoms/Dropdown.module.css
@@ -1,12 +1,12 @@
-.customDropdown { 
-  font-size: 1rem;
-  font-style: normal; 
+.customDropdown {
+  font-size: 1.6rem;
+  font-style: normal;
   font-weight: 400;
   color: #818181;
-  padding: 0.5625rem 1.25rem;
-  border-radius: 0.625rem;
-  background-color: #fff;
-  cursor: pointer; 
+  padding: 0.9rem 2rem;
+  border-radius: 1rem;
+  background-color: var(--background-secondary);
+  cursor: pointer;
 }
 
 .customDropdown option {

--- a/src/styles/components/organisms/Card.module.css
+++ b/src/styles/components/organisms/Card.module.css
@@ -3,8 +3,8 @@
 .card {
   position: relative;
   width: 100%;
-  max-width: 400px;
-  height: 200px;
+  max-width: 35.8rem;
+  min-height: 24.3rem;
   border-radius: 12px;
   overflow: hidden;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
@@ -36,7 +36,7 @@
 .cardContent {
   position: relative;
   z-index: 1;
-  padding: 16px;
+  padding: 3rem 3.4rem 3rem 3rem;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -46,21 +46,30 @@
 
 .tagSection {
   display: flex;
-  justify-content: flex-start;
-  align-items: flex-start;
+  justify-content: space-between;
+  align-items: center;
+
+  h3 {
+    display: flex;
+    align-items: center;
+
+    b {
+      font-weight: 700;
+    }
+  }
 }
 
 .textSection {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 3rem;
   margin-top: 8px;
 }
 
 .textSection h3 {
   margin: 0;
-  font-size: 18px;
+  font-size: 1.8rem;
   font-weight: bold;
   line-height: 1.3;
 }
@@ -70,13 +79,13 @@
   line-height: 1.4;
 }
 
-.textSection p:nth-child(2) {
-  font-size: 12px;
-  opacity: 0.9;
+.textSection p:nth-child(1) {
+  font-size: 1.4rem;
+  color: var(--text-gray);
 }
 
-.textSection p:nth-child(3) {
-  font-size: 14px;
+.textSection p:nth-child(2) {
+  font-size: 1.6rem;
   margin-top: 4px;
 }
 

--- a/src/styles/components/organisms/Header.module.css
+++ b/src/styles/components/organisms/Header.module.css
@@ -3,6 +3,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 2.5rem 20rem;
+  margin-bottom: 4rem;
 }
 
 @media (max-width: 1024px) {

--- a/src/styles/pages/StudyPage.module.css
+++ b/src/styles/pages/StudyPage.module.css
@@ -1,14 +1,39 @@
-.studyPage {
+.studyPageContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+  width: 100%;
+  max-width: 120rem;
+  margin: 0 auto;
+}
+
+.studyPageWrapper {
   font-size: 1.6rem;
-  background-color: #f5f5f5;
-  text-align: center;
-  padding: 2.5rem 20rem;
+  border-radius: 2rem;
+  background-color: var(--background-secondary);
+  padding: 4rem;
+}
+
+.studyListFilter {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2.4rem;
+
+  input {
+    border: 1px solid var(--border-gray);
+    border-radius: 0.8rem;
+    padding: 0.8rem 1.6rem;
+    font-size: 1.6rem;
+    width: 33.5rem;
+    max-width: 40rem;
+  }
 }
 
 .studyList {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 2.5rem;
+  gap: 2.4rem;
 }
 
 .studyPageTitle {

--- a/src/utils/api/study/getStudyApi.js
+++ b/src/utils/api/study/getStudyApi.js
@@ -1,7 +1,7 @@
 import { instance } from '../axiosInstance';
 
 const getStudyApi = async () => {
-  const response = await instance.get('/study');
+  const response = await instance.get('/api/studies');
   return response.data;
 };
 

--- a/src/utils/constants/cardPresets.js
+++ b/src/utils/constants/cardPresets.js
@@ -1,12 +1,14 @@
 // 카드 프리셋 정의
 export const CARD_PRESETS = {
   // 단색 배경 프리셋
-  SOLID_GRAY: {
+  SOLID_BLUE: {
     id: 'solid-gray',
-    name: '회색',
+    name: '파란색',
     type: 'solid',
-    backgroundColor: '#9CA3AF',
-    textColor: '#FFFFFF',
+    backgroundColor: 'var(--card-blue)',
+    titleTextColor: 'var(--text-primary)',
+    dayTextColor: 'var(--text-gray)',
+    descriptionTextColor: 'var(--text-primary)',
     overlayOpacity: 0,
   },
   SOLID_GREEN: {
@@ -14,7 +16,7 @@ export const CARD_PRESETS = {
     name: '연두색',
     type: 'solid',
     backgroundColor: '#84CC16',
-    textColor: '#FFFFFF',
+
     overlayOpacity: 0,
   },
   SOLID_MINT: {


### PR DESCRIPTION
### 반영 브랜치
ex) feat/study-page -> dev

### 변경 사항
- [x] dayjs 라이브러리를 dependencies에 추가
- [x] 카드 컴포넌트에서 진행 중인 일수를 계산하여 표시하도록 수정
- [x] 텍스트 컴포넌트 사용 예시 및 스타일 업데이트
- [x] 스터디 페이지 레이아웃 개선 및 필터 기능 추가
- [x] 드롭다운 컴포넌트 스타일 수정

### 테스트 결과
- 테스트 결과 정상으로 보임

### 참고 사항 (Optional)
- 중간 발표를 위해 급한 PR올립니다.
- 프론트엔드 netlify로 배포하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Study 페이지를 “최근 조회한 스터디”와 “스터디 둘러보기(필터+드롭다운)”로 개편
  - 카드에 닉네임 기반 헤더와 생성일 기준 “N일째 진행 중” 표시 추가
- Style
  - 카드 크기·여백·타이포그래피 개선, 이모지 기본 카운트 조정
  - 드롭다운 폰트/패딩/라운드 업그레이드
  - 헤더 하단 여백 추가, 페이지 래퍼 카드형 스타일 적용, 그리드 간격 조정
  - 카드 블루 색상 미세 조정, 텍스트 기본 색 처리 변경
- Documentation
  - Text 컴포넌트 사용 가이드 추가
- Chores
  - dayjs 의존성 추가
  - 스터디 목록 API 경로 업데이트
  - 카드 프리셋 색상/키 정리 (SOLID_BLUE)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->