### PR TITLE
feat(search-bar): improve input styles & add left icon slot

### DIFF
--- a/src/components/atoms/Input.jsx
+++ b/src/components/atoms/Input.jsx
@@ -4,7 +4,7 @@ import styles from "../../styles/components/atoms/Input.module.css";
 /**
  * Pure Input atom — 라벨/헬퍼/에러 문구 없이 시각 상태만.
  * - invalid: 테두리만 빨강
- * - rightSlot: 아이콘/버튼(예: 비밀번호 토글) 붙일 때 사용
+ * - leftSlot/rightSlot: 아이콘/버튼(검색, 비번 토글 등)
  * - forwardRef 지원 (포커스 제어 등)
  */
 const Input = forwardRef(function Input(
@@ -15,16 +15,29 @@ const Input = forwardRef(function Input(
     placeholder,
     disabled = false,
     invalid = false,
+    leftSlot = null,
     rightSlot = null,
     className = "",
+    size, // 선택: "size-lg" / "size-mobile" 등
     ...rest
   },
-  ref,
+  ref
 ) {
+  const hasLeft = !!leftSlot;
   const hasRight = !!rightSlot;
 
   return (
-    <div className={`${styles.wrap} ${hasRight ? styles.hasRight : ""} ${className}`}>
+    <div
+      className={[
+        styles.wrap,
+        hasLeft ? styles.hasLeft : "",
+        hasRight ? styles.hasRight : "",
+        size ? styles[size] : "",
+        className,
+      ].join(" ").trim()}
+    >
+      {hasLeft ? <div className={styles.leftSlot}>{leftSlot}</div> : null}
+
       <input
         className={`${styles.input} ${invalid ? styles.invalid : ""}`}
         {...(value !== undefined ? { value } : {})}
@@ -36,6 +49,7 @@ const Input = forwardRef(function Input(
         ref={ref}
         {...rest}
       />
+
       {hasRight ? <div className={styles.rightSlot}>{rightSlot}</div> : null}
     </div>
   );

--- a/src/components/atoms/Input.jsx
+++ b/src/components/atoms/Input.jsx
@@ -1,11 +1,13 @@
+// src/components/atoms/Input.jsx
 import { forwardRef } from "react";
 import styles from "../../styles/components/atoms/Input.module.css";
 
 /**
  * Pure Input atom — 라벨/헬퍼/에러 문구 없이 시각 상태만.
  * - invalid: 테두리만 빨강
- * - leftSlot/rightSlot: 아이콘/버튼(검색, 비번 토글 등)
- * - forwardRef 지원 (포커스 제어 등)
+ * - leftSlot / rightSlot: 아이콘/버튼 오버레이
+ * - size: "lg" | "mobile" (내부에서 size-${token} 클래스로 매핑)
+ * - leftInteractive: 왼쪽 아이콘을 클릭 가능하게 전환 (기본 false)
  */
 const Input = forwardRef(function Input(
   {
@@ -17,11 +19,12 @@ const Input = forwardRef(function Input(
     invalid = false,
     leftSlot = null,
     rightSlot = null,
+    size,                 // "lg" | "mobile"
+    leftInteractive = false,
     className = "",
-    size, // 선택: "size-lg" / "size-mobile" 등
     ...rest
   },
-  ref
+  ref,
 ) {
   const hasLeft = !!leftSlot;
   const hasRight = !!rightSlot;
@@ -30,16 +33,19 @@ const Input = forwardRef(function Input(
     <div
       className={[
         styles.wrap,
-        hasLeft ? styles.hasLeft : "",
-        hasRight ? styles.hasRight : "",
-        size ? styles[size] : "",
+        hasLeft && styles.hasLeft,
+        hasRight && styles.hasRight,
+        size && styles[`size-${size}`],
+        leftInteractive && styles.leftInteractive,
         className,
-      ].join(" ").trim()}
+      ].filter(Boolean).join(" ")}
     >
       {hasLeft ? <div className={styles.leftSlot}>{leftSlot}</div> : null}
-
       <input
-        className={`${styles.input} ${invalid ? styles.invalid : ""}`}
+        className={[
+          styles.input,
+          invalid && styles.invalid,
+        ].filter(Boolean).join(" ")}
         {...(value !== undefined ? { value } : {})}
         {...(onChange ? { onChange } : {})}
         type={type}
@@ -49,7 +55,6 @@ const Input = forwardRef(function Input(
         ref={ref}
         {...rest}
       />
-
       {hasRight ? <div className={styles.rightSlot}>{rightSlot}</div> : null}
     </div>
   );

--- a/src/components/molecules/SearchBar.jsx
+++ b/src/components/molecules/SearchBar.jsx
@@ -1,0 +1,59 @@
+import React, { useRef } from "react";
+import Input from "../atoms/Input.jsx";
+
+function MagnifierIcon(props) {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      {...props}
+    >
+      <path
+        d="M21 21l-4.2-4.2m1.2-5.3a6.5 6.5 0 11-13 0 6.5 6.5 0 0113 0z"
+        stroke="#8A8A8A"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export default function SearchBar({
+  value,
+  onChange,
+  onSubmit,
+  placeholder = "검색어를 입력하세요",
+  size = "lg",
+  debounceMs = 0,
+  autoFocus = false,
+}) {
+  const inputRef = useRef(null);
+
+  const handleKeyDown = (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      onSubmit?.(e.target.value);
+    }
+  };
+
+  const handleChange = (e) => {
+    onChange?.(e.target.value);
+  };
+
+  return (
+    <Input
+      value={value}
+      onChange={handleChange}
+      onKeyDown={handleKeyDown}
+      placeholder={placeholder}
+      size={`size-${size}`}   /* "size-lg" / "size-mobile" */
+      leftSlot={<MagnifierIcon />}  /* ← 왼쪽으로 이동 */
+      autoFocus={autoFocus}
+      type="text"
+    />
+  );
+}

--- a/src/components/molecules/SearchBar.jsx
+++ b/src/components/molecules/SearchBar.jsx
@@ -1,59 +1,64 @@
-import React, { useRef } from "react";
+// src/components/molecules/SearchBar.jsx
+import React from "react";
 import Input from "../atoms/Input.jsx";
-
-function MagnifierIcon(props) {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 24 24"
-      fill="none"
-      aria-hidden="true"
-      {...props}
-    >
-      <path
-        d="M21 21l-4.2-4.2m1.2-5.3a6.5 6.5 0 11-13 0 6.5 6.5 0 0113 0z"
-        stroke="#8A8A8A"
-        strokeWidth="1.8"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
+import styles from "../../styles/components/molecules/SearchBar.module.css";
 
 export default function SearchBar({
   value,
   onChange,
   onSubmit,
   placeholder = "검색어를 입력하세요",
-  size = "lg",
-  debounceMs = 0,
+  size = "lg",            // "lg" | "mobile"
   autoFocus = false,
+  leftIcon = (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        d="M21 21l-4.35-4.35m1.35-5.65a7 7 0 11-14 0 7 7 0 0114 0z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  ),
 }) {
-  const inputRef = useRef(null);
+  const handleChange = (e) => {
+    onChange?.(e.target.value);
+  };
 
   const handleKeyDown = (e) => {
     if (e.key === "Enter") {
+      // IME(한/중/일) 조합 중 Enter 방지
+      if (e.isComposing || e.nativeEvent?.isComposing) return;
       e.preventDefault();
       onSubmit?.(e.target.value);
     }
   };
 
-  const handleChange = (e) => {
-    onChange?.(e.target.value);
-  };
-
   return (
-    <Input
-      value={value}
-      onChange={handleChange}
-      onKeyDown={handleKeyDown}
-      placeholder={placeholder}
-      size={`size-${size}`}   /* "size-lg" / "size-mobile" */
-      leftSlot={<MagnifierIcon />}  /* ← 왼쪽으로 이동 */
-      autoFocus={autoFocus}
-      type="text"
-    />
+    <div className={styles.form}>
+      {/* 시각적 라벨이 없으므로 aria-label 부여 */}
+      <Input
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+        type="search"
+        role="searchbox"
+        aria-label={placeholder}
+        // 사이즈 토큰 그대로 전달 → Input에서 size-${size}로 변환
+        size={size}
+        leftSlot={<span className={styles.leftSpace}>{leftIcon}</span>}
+        // 검색 아이콘은 클릭 불필요 → leftInteractive 기본 false
+      />
+    </div>
   );
 }

--- a/src/pages/TestPage.jsx
+++ b/src/pages/TestPage.jsx
@@ -8,10 +8,11 @@ import EmojiCounter from "../components/molecules/EmojiCounter";
 import TodayHabitModal from "../components/organisms/TodayHabitModal.jsx";
 import StudyPasswordModal from "../components/organisms/StudyPasswordModal.jsx";
 import Card from "../components/organisms/Card.jsx";
+import SearchBar from "../components/molecules/SearchBar.jsx";   // ✅ 주석 해제
 
 export default function TestPage() {
   /** ------------------------------
-   *  EmojiCounter demo (develop)
+   *  EmojiCounter demo
    *  ------------------------------ */
   const emojiData = [
     { id: 1, emoji: "👍", count: 1 },
@@ -19,7 +20,7 @@ export default function TestPage() {
   ];
 
   /** ------------------------------
-   *  Chip demo (develop)
+   *  Chip demo
    *  ------------------------------ */
   const [chips, setChips] = useState([
     { id: "1", label: "미라클모닝 6시 기상", selected: false },
@@ -66,39 +67,53 @@ export default function TestPage() {
   };
 
   /** ------------------------------
-   *  TodayHabitModal demo (develop)
+   *  TodayHabitModal demo
    *  ------------------------------ */
   const [openHabitModal, setOpenHabitModal] = useState(false);
-  const [items, setItems] = useState([]); // 비어 있으면 Add만 보임
-
+  const [items, setItems] = useState([]);
   const addItem = () => setItems((prev) => [...prev, "새 습관"]);
-  const deleteItem = (idx) =>
-    setItems((prev) => prev.filter((_, i) => i !== idx));
-
+  const deleteItem = (idx) => setItems((prev) => prev.filter((_, i) => i !== idx));
   const handleHabitClose = () => setOpenHabitModal(false);
-  const handleHabitSave = () => {
-    // TODO: 저장 로직 연동
-    setOpenHabitModal(false); // 저장 후 닫기
+  const handleHabitSave = () => setOpenHabitModal(false);
+
+  /** ------------------------------
+   *  StudyPasswordModal demo
+   *  ------------------------------ */
+  const [isOpenStudyModal, setIsOpenStudyModal] = useState(false);
+  const handleVerify = async (password) => {
+    if (password !== "1234") return false;
+    setIsOpenStudyModal(false);
+    return true;
   };
 
   /** ------------------------------
-   *  StudyPasswordModal demo (feature)
+   *  SearchBar demo
    *  ------------------------------ */
-  const [openStudyModal, setOpenStudyModal] = useState(false);
-
-  // 데모 검증: "1234"만 통과
-  const verifyStudyPassword = async (pw) => pw === "1234";
+  const [search, setSearch] = useState("");
 
   return (
     <div style={{ display: "grid", gap: "2rem", padding: "1.6rem" }}>
       <header style={{ display: "flex", gap: "1rem" }}>
-        <Button variant="action" size="md" onClick={() => setOpenHabitModal(true)}>
-          오늘의 습관 모달 열기
+        <Button variant="action" size="lg" onClick={() => setOpenHabitModal(true)}>
+          오늘의 습관 모달
         </Button>
-        <Button variant="action" size="md" onClick={() => setOpenStudyModal(true)}>
-          스터디 비밀번호 모달 열기
+        <Button variant="action" size="lg" onClick={() => setIsOpenStudyModal(true)}>
+          스터디 비밀번호모달
         </Button>
       </header>
+
+      {/* ✅ SearchBar lg */}
+      <section>
+        <h2>SearchBar Test</h2>
+        <SearchBar
+          value={search}
+          onChange={(v) => setSearch(v)}
+          onSubmit={(v) => setSearch(v)}
+          placeholder="스터디 검색"
+          size="lg"
+        />
+        <p style={{ marginTop: "1rem" }}>검색어: {search}</p>
+      </section>
 
       <section>
         <h2>EmojiCounter Test</h2>
@@ -125,7 +140,6 @@ export default function TestPage() {
         </div>
       </section>
 
-      {/* TodayHabitModal (develop) */}
       <TodayHabitModal
         open={openHabitModal}
         items={items}
@@ -135,11 +149,10 @@ export default function TestPage() {
         onSave={handleHabitSave}
       />
 
-      {/* StudyPasswordModal (feature) */}
       <StudyPasswordModal
-        isOpen={openStudyModal}
-        onClose={() => setOpenStudyModal(false)}
-        onVerify={verifyStudyPassword}
+        isOpen={isOpenStudyModal}
+        onClose={() => setIsOpenStudyModal(false)}
+        onVerify={handleVerify}
       />
     </div>
   );

--- a/src/styles/components/atoms/Input.module.css
+++ b/src/styles/components/atoms/Input.module.css
@@ -1,57 +1,67 @@
+/* 1rem = 10px 기준 */
+
 .wrap {
   position: relative;
+  display: flex;
+  align-items: center;
   width: 100%;
 }
 
 .input {
   width: 100%;
-  height: 44px;
-  border: 1px solid var(--background-neutral, #e5e7eb);
-  border-radius: 8px;
-  padding: 0 12px;
-  font-size: 16px;
-  line-height: 1.2;
-  background: var(--background-secondary, #fff);
-  color: var(--text-primary, #111827);
-  outline: 0;
-  transition: border-color 120ms ease, box-shadow 120ms ease, background-color 120ms ease;
-}
-
-.input::placeholder {
-  color: var(--text-gray, #6b7280);
+  height: 1.8rem;
+  box-sizing: border-box;
+  border: 0.1rem solid #e5e7eb;
+  border-radius: 0.5rem; 
+  background: #fff;
+  color: var(--text-primary, #414141);
+  font-size: 1.4rem;
+  line-height: 1.4;
+  padding: 1.5rem 2.0rem;
+  outline: none;
 }
 
 .input:focus {
-  border-color: var(--brand-blue, #0013a7);
-  box-shadow: 0 0 0 2px rgba(0, 19, 167, 0.12);
+  border-color: #c7d2fe;
+  box-shadow: 0 0 0 0.2rem rgba(59, 130, 246, 0.15);
 }
 
-/* Keyboard-only focus ring */
-.input:focus-visible {
-  border-color: var(--brand-blue, #0013a7);
-  box-shadow: 0 0 0 2px rgba(0, 19, 167, 0.12);
+.invalid {
+  border-color: #ef4444;
 }
 
-.input:disabled {
-  background: #f3f4f6;
-  color: #9ca3af;
-  cursor: not-allowed;
-}
-
-.input.invalid {
-  border-color: var(--warning-red, #dc2626);
-  box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.08);
-}
-
-/* 오른쪽 아이콘/버튼이 있을 때 입력 텍스트 겹침 방지 */
-.hasRight .input { padding-right: 44px; }
-
+/* ---- 아이콘/버튼 영역 (오른쪽) ---- */
 .rightSlot {
   position: absolute;
-  top: 50%;
-  right: 8px;
-  transform: translateY(-50%);
+  right: 0.8rem;
   display: grid;
   place-items: center;
-  pointer-events: auto;
+  height: 100%;
+}
+
+.hasRight .input {
+  padding-right: 4.0rem; /* 아이콘 자리 확보 */
+}
+
+/* ---- 아이콘/버튼 영역 (왼쪽) ---- */
+.leftSlot {
+  position: absolute;
+  left: 0.8rem;
+  display: grid;
+  place-items: center;
+  height: 100%;
+  pointer-events: none; /* 아이콘 클릭 필요 시 제거 */
+}
+
+.hasLeft .input {
+  padding-left: 4.0rem; /* 왼쪽 아이콘 자리 확보 */
+}
+
+/* ===== 넓이 프리셋 ===== */
+.size-lg {
+  width: 29.5rem;   /* PC */
+}
+
+.size-mobile {
+  width: 27.2rem;   /* Mobile */
 }

--- a/src/styles/components/atoms/Input.module.css
+++ b/src/styles/components/atoms/Input.module.css
@@ -9,7 +9,6 @@
 
 .input {
   width: 100%;
-  height: 1.8rem;
   box-sizing: border-box;
   border: 0.1rem solid #e5e7eb;
   border-radius: 0.5rem; 
@@ -17,7 +16,7 @@
   color: var(--text-primary, #414141);
   font-size: 1.4rem;
   line-height: 1.4;
-  padding: 1.5rem 2.0rem;
+  padding: 0.9rem 2.0rem;
   outline: none;
 }
 
@@ -28,6 +27,12 @@
 
 .invalid {
   border-color: #ef4444;
+}
+
+/* 포커스 시에도 invalid 유지 */
+.input.invalid:focus {
+  border-color: #ef4444;
+  box-shadow: 0 0 0 0.2rem rgba(239, 68, 68, 0.15);
 }
 
 /* ---- 아이콘/버튼 영역 (오른쪽) ---- */
@@ -50,7 +55,12 @@
   display: grid;
   place-items: center;
   height: 100%;
-  pointer-events: none; /* 아이콘 클릭 필요 시 제거 */
+  pointer-events: none; /* 기본은 클릭 불가 (검색 등) */
+}
+
+/* 래퍼에 .leftInteractive 붙이면 클릭 가능 */
+.leftInteractive .leftSlot {
+  pointer-events: auto;
 }
 
 .hasLeft .input {

--- a/src/styles/components/molecules/SearchBar.module.css
+++ b/src/styles/components/molecules/SearchBar.module.css
@@ -1,0 +1,52 @@
+/* SearchBar.module.css */
+.form {
+  width: 100%;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.inputWrap {
+  position: relative;
+}
+
+.rightSlot {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.iconBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #666;
+}
+
+.iconBtn:hover {
+  background-color: #f5f5f5;
+}
+
+.iconBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.rightSpace {
+  width: 18px;
+  height: 18px;
+}

--- a/src/styles/components/molecules/SearchBar.module.css
+++ b/src/styles/components/molecules/SearchBar.module.css
@@ -1,52 +1,52 @@
-/* SearchBar.module.css */
 .form {
   width: 100%;
 }
 
-.srOnly {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+/* 인풋 좌측 아이콘 크기/여백 */
+.leftSpace {
+  display: inline-flex;
+  width: var(--icon-size, 18px);
+  height: var(--icon-size, 18px);
+  align-items: center;
+  justify-content: center;
+  color: #666;
 }
 
-.inputWrap {
-  position: relative;
-}
-
+/* 우측에 붙는 작은 버튼들(선택 사용) */
 .rightSlot {
   display: flex;
   align-items: center;
   gap: 4px;
 }
 
+/* 아이콘 버튼 접근성 보강 */
 .iconBtn {
   background: none;
   border: none;
   cursor: pointer;
   padding: 4px;
+  min-width: 36px;   /* 가능하면 40~44px */
+  min-height: 36px;  /* 가능하면 40~44px */
   border-radius: 4px;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #666;
+  color: var(--color-icon, #666);
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  transition: background-color 120ms ease, color 120ms ease, outline-color 120ms ease;
 }
 
-.iconBtn:hover {
-  background-color: #f5f5f5;
+/* 포인터/호버 가능한 디바이스에만 hover 적용 */
+@media (hover: hover) and (pointer: fine) {
+  .iconBtn:hover {
+    background-color: var(--color-hover-bg, #f5f5f5);
+  }
 }
 
-.iconBtn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+/* 키보드 포커스 가시성 */
+.iconBtn:focus-visible {
+  outline-color: var(--color-focus, #2684FF);
+  background-color: var(--color-focus-bg, #eef5ff);
 }
 
-.rightSpace {
-  width: 18px;
-  height: 18px;
-}


### PR DESCRIPTION
### 반영 브랜치
feat/search-bar → develop

### 변경 사항
SearchBar Molecule (PC / Mobile)
- [x] Input atom 기반 SearchBar molecule 추가
- [x] 검색 아이콘을 input 왼쪽에 배치 (leftSlot 활용)
- [x] 사이즈 프리셋
         PC: 29.5rem (size-lg)
         Mobile: 27.2rem (size-mobile)
- [x] focus 시 outline/box-shadow 스타일 적용

Input Atom
- [x] leftSlot / rightSlot 아이콘 영역 지원
- [x] padding 보정 처리 (아이콘 영역 확보)

### 테스트 결과
- PC 화면에서 SearchBar UI 사이즈, focus 효과 정상 동작 확인
- Mobile 화면에서 SearchBar 폭 정상 반영
- 아이콘이 input 왼쪽에 고정 배치되는 것 확인
- 검색어 입력 시 필터링 로직 정상 동작 확인

### Test image
<img width="324" height="70" alt="Screenshot 2025-09-03 at 3 17 08 PM" src="https://github.com/user-attachments/assets/1047ccb1-e695-4331-bdab-755c9003f1b4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신규 기능
  * 입력 컴포넌트가 왼쪽 슬롯(leftSlot), 좌측 클릭 허용(leftInteractive) 및 크기(size) 옵션을 지원합니다.
  * 돋보기 기본 아이콘과 Enter 제출을 지원하는 검색바 컴포넌트를 추가했습니다(기본 플레이스홀더: "검색어를 입력하세요").

* 스타일
  * 입력 필드 시각을 전면 개편하고 좌/우 아이콘 영역, 포커스·에러 상태, 크기 프리셋을 도입했습니다.
  * 검색바 레이아웃 및 아이콘 버튼 스타일을 추가했습니다.

* 리팩터
  * 데모 페이지에 검색바 섹션을 추가하고 모달 데모 라벨·버튼 크기 및 일부 상호작용을 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->