### PR TITLE
feat: 로그인 및 회원가입 페이지 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,17 @@
       "name": "8-studyforest-team2-fe",
       "version": "0.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.1",
         "axios": "^1.11.0",
         "dayjs": "^1.11.18",
         "emoji-picker-react": "^4.13.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-hook-form": "^7.62.0",
         "react-router-dom": "^7.8.2",
-        "zustand": "^5.0.8"
+        "zod": "^4.1.5",
+        "zustand": "^5.0.8",
+        "zustand-persist": "^0.4.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -857,6 +861,18 @@
         "url": "https://eslint.org/donate"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.1.tgz",
+      "integrity": "sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1277,6 +1293,12 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -4912,6 +4934,22 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6222,6 +6260,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.5.tgz",
+      "integrity": "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/zustand": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
@@ -6249,6 +6296,16 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zustand-persist": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/zustand-persist/-/zustand-persist-0.4.0.tgz",
+      "integrity": "sha512-u6bBIc4yZRpSKBKuTNhoqvoIb09gGHk2NkiPg4K7MPIWTYZg70PlpBn48QEDnKZwfNurnf58TaW5BuMGIMf5hw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "zustand": ">=3.6.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,13 +11,17 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.1",
     "axios": "^1.11.0",
     "dayjs": "^1.11.18",
     "emoji-picker-react": "^4.13.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-hook-form": "^7.62.0",
     "react-router-dom": "^7.8.2",
-    "zustand": "^5.0.8"
+    "zod": "^4.1.5",
+    "zustand": "^5.0.8",
+    "zustand-persist": "^0.4.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/components/atoms/Input.jsx
+++ b/src/components/atoms/Input.jsx
@@ -1,5 +1,5 @@
-import React from "react";
-import styles from "../../styles/components/atoms/Input.module.css";
+import React from 'react';
+import styles from '../../styles/components/atoms/Input.module.css';
 
 /**
  * 기본 Input 컴포넌트 (재사용 가능)
@@ -10,11 +10,11 @@ export default function Input({
   onBlur,
   onKeyDown,
   placeholder,
-  type = "text",
+  type = 'text',
   size, // "lg" | "mobile" 등 (내부에서 size-${size}로 변환)
   autoFocus = false,
   disabled = false,
-  className = "",
+  className = '',
   leftSlot,
   rightSlot,
   leftInteractive = false,
@@ -33,14 +33,12 @@ export default function Input({
         size && styles[`size-${size}`],
         leftInteractive && styles.leftInteractive,
         className,
-      ].filter(Boolean).join(" ")}
+      ]
+        .filter(Boolean)
+        .join(' ')}
       style={style}
     >
-      {hasLeft && (
-        <div className={styles.leftSlot}>
-          {leftSlot}
-        </div>
-      )}
+      {hasLeft && <div className={styles.leftSlot}>{leftSlot}</div>}
 
       <input
         className={styles.input}
@@ -55,11 +53,7 @@ export default function Input({
         {...rest}
       />
 
-      {hasRight && (
-        <div className={styles.rightSlot}>
-          {rightSlot}
-        </div>
-      )}
+      {hasRight && <div className={styles.rightSlot}>{rightSlot}</div>}
     </div>
   );
 }

--- a/src/components/atoms/Toast.jsx
+++ b/src/components/atoms/Toast.jsx
@@ -1,23 +1,29 @@
-import styles from "../../styles/components/atoms/Toast.module.css";
+import styles from '../../styles/components/atoms/Toast.module.css';
 
-export default function Toast({ type, point = 0, className = "" }) {
+export default function Toast({
+  type,
+  point = 0,
+  className = '',
+  message = '',
+}) {
   const messageMap = {
-    error: "집중이 중단되었습니다.",
-    mismatch: "비밀번호가 일치하지 않습니다. 다시 입력해주세요.",
+    error: '집중이 중단되었습니다.',
+    mismatch: '비밀번호가 일치하지 않습니다. 다시 입력해주세요.',
     point: `${point}포인트를 획득했습니다!`,
+    basic: message,
   };
 
   const iconMap = {
-    error: "🚨",
-    mismatch: "🚨",
-    point: "🎉",
+    error: '🚨',
+    mismatch: '🚨',
+    point: '🎉',
   };
 
-  const allowedTypes = ["error", "mismatch", "point"];
-  const safeType = allowedTypes.includes(type) ? type : "error";
+  const allowedTypes = ['error', 'mismatch', 'point', 'basic'];
+  const safeType = allowedTypes.includes(type) ? type : 'error';
 
   // role만으로 라이브영역이 암묵 지정됨 (alert=assertive, status=polite)
-  const role = safeType === "point" ? "status" : "alert";
+  const role = safeType === 'point' ? 'status' : 'alert';
 
   return (
     <div
@@ -25,7 +31,7 @@ export default function Toast({ type, point = 0, className = "" }) {
       role={role}
       aria-atomic={true}
     >
-      <span aria-hidden="true">{iconMap[safeType]}</span>
+      {iconMap[safeType] && <span aria-hidden="true">{iconMap[safeType]}</span>}
       <span className={styles.text}>{messageMap[safeType]}</span>
     </div>
   );

--- a/src/components/organisms/Card.jsx
+++ b/src/components/organisms/Card.jsx
@@ -5,10 +5,12 @@ import Emoji from '../atoms/Emoji';
 import { CARD_PRESETS } from '../../utils/constants/cardPresets';
 import dayjs from 'dayjs';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 /**
  * Card 컴포넌트
  * @param {Object} props
+ * @param {string} props.id - 스터디 ID
  * @param {string} props.preset - 프리셋 ID (CARD_PRESETS의 키)
  * @param {string} props.backgroundImage - 커스텀 배경 이미지 URL
  * @param {string} props.backgroundColor - 커스텀 배경색
@@ -26,6 +28,7 @@ import { useEffect, useState } from 'react';
  */
 export default function Card({
   preset,
+  id,
   backgroundImage,
   backgroundColor,
   overlayOpacity,
@@ -43,6 +46,7 @@ export default function Card({
   isSelected = false,
 }) {
   const [daysPassed, setDaysPassed] = useState(createdAt);
+  const navigate = useNavigate();
   // 프리셋이 있으면 프리셋 사용, 없으면 직접 전달된 props 사용
   const presetData = preset ? CARD_PRESETS[preset] : null;
 
@@ -77,6 +81,8 @@ export default function Card({
         },
       );
     }
+
+    navigate(`/study/${id}`);
   };
 
   const calculateDaysPassed = createdAt => {

--- a/src/components/organisms/Header.jsx
+++ b/src/components/organisms/Header.jsx
@@ -37,17 +37,25 @@ export function Header() {
       </div>
 
       {/* 스터디 만들기 버튼 */}
-      {isMainPage && (
-        <div>
-          <Button
-            onClick={handleLinkToCreateStudy}
-            variant="action"
-            size="ctrl-sm"
-          >
-            스터디 만들기
-          </Button>
-        </div>
-      )}
+      <div className={styles.headerButtons}>
+        <Link className={styles.headerButton} to="/register">
+          회원가입
+        </Link>
+        <Link className={styles.headerButton} to="/login">
+          로그인
+        </Link>
+        {isMainPage && (
+          <div>
+            <Button
+              onClick={handleLinkToCreateStudy}
+              variant="action"
+              size="ctrl-sm"
+            >
+              스터디 만들기
+            </Button>
+          </div>
+        )}
+      </div>
     </header>
   );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -10,6 +10,9 @@ import { StudyPage } from './pages/StudyPage';
 import TestPage from './pages/TestPage';
 import FocusPage from './pages/FocusPage';
 import { StudyCreatePage } from './pages/StudyCreatePage';
+import RegisterPage from './pages/RegisterPage';
+import LoginPage from './pages/LoginPage';
+import StudyDetailPage from './pages/StudyDetailPage';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
@@ -20,6 +23,9 @@ createRoot(document.getElementById('root')).render(
           <Route path="/focus" element={<FocusPage />} />
           <Route path="/test" element={<TestPage />} />
           <Route path="/study/new" element={<StudyCreatePage />} />
+          <Route path="/study/:id" element={<StudyDetailPage />} />
+          <Route path="/register" element={<RegisterPage />} />
+          <Route path="/login" element={<LoginPage />} />
         </Route>
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,0 +1,139 @@
+// src/pages/LoginPage.jsx
+import { useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import Input from '../components/atoms/Input.jsx';
+import Button from '../components/atoms/Button.jsx';
+import PasswordInput from '../components/molecules/PasswordInput.jsx';
+import Toast from '../components/atoms/Toast.jsx';
+import { loginSchema } from '../utils/validation/loginSchema.js';
+import { userApi } from '../utils/api/user/postLoginApi.js';
+import styles from '../styles/pages/LoginPage.module.css';
+
+/**
+ * 로그인 페이지
+ */
+export default function LoginPage() {
+  const navigate = useNavigate();
+
+  // 폼 상태 관리
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting, isValid },
+  } = useForm({
+    resolver: zodResolver(loginSchema),
+    mode: 'onBlur',
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+  });
+
+  // 로그인 처리
+  const onSubmit = async data => {
+    try {
+      const response = await userApi.postLoginApi(data);
+      console.log('로그인 성공:', response);
+      Toast({ type: 'basic', message: '로그인이 완료되었습니다.' });
+      navigate('/');
+    } catch (error) {
+      console.error('로그인 실패:', error);
+      Toast({
+        type: 'basic',
+        message: '로그인에 실패했습니다. 다시 시도해 주세요.',
+      });
+    }
+  };
+
+  // 회원가입 페이지로 이동
+  const handleLinkToRegister = () => {
+    navigate('/register');
+  };
+
+  return (
+    <main className={styles.page}>
+      <form
+        className={styles.card}
+        onSubmit={handleSubmit(onSubmit)}
+        noValidate
+      >
+        {/* 헤더 */}
+        <div className={styles.header}>
+          <h1 className={styles.title}>로그인</h1>
+          <p className={styles.subtitle}>
+            MindMeld에 다시 오신 것을 환영합니다
+          </p>
+        </div>
+
+        {/* 이메일 */}
+        <section className={styles.section}>
+          <label className={styles.label} htmlFor="email">
+            이메일
+          </label>
+          <Input
+            id="email"
+            type="email"
+            placeholder="이메일을 입력해 주세요"
+            {...register('email')}
+            aria-invalid={!!errors.email}
+            aria-describedby={errors.email ? 'email-error' : undefined}
+          />
+          <div className={styles.errorSlot}>
+            {errors.email && (
+              <p id="email-error" className={styles.error}>
+                {errors.email.message}
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* 비밀번호 */}
+        <section className={styles.section}>
+          <PasswordInput
+            placeholder="비밀번호를 입력해 주세요"
+            label="비밀번호"
+            autoComplete="current-password"
+            {...register('password')}
+            aria-invalid={!!errors.password}
+            aria-describedby={errors.password ? 'password-error' : undefined}
+          />
+          <div className={styles.errorSlot}>
+            {errors.password && (
+              <p id="password-error" className={styles.error}>
+                {errors.password.message}
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* 로그인 버튼 */}
+        <div className={styles.cta}>
+          <Button
+            variant="action"
+            size="xl"
+            type="submit"
+            className={styles.submitButton}
+            disabled={isSubmitting || !isValid}
+          >
+            {isSubmitting ? '로그인 중...' : '로그인'}
+          </Button>
+        </div>
+
+        {/* 회원가입 링크 */}
+        <div className={styles.registerLink}>
+          <p>
+            아직 계정이 없으신가요?
+            <button
+              type="button"
+              className={styles.linkButton}
+              onClick={handleLinkToRegister}
+            >
+              회원가입하기
+            </button>
+          </p>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -1,0 +1,204 @@
+// src/pages/RegisterPage.jsx
+import { useNavigate } from 'react-router-dom';
+import Input from '../components/atoms/Input.jsx';
+import Button from '../components/atoms/Button.jsx';
+import PasswordInput from '../components/molecules/PasswordInput.jsx';
+import styles from '../styles/pages/RegisterPage.module.css';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { registerSchema } from '../utils/validation/registerSchema.js';
+import { userApi } from '../utils/api/user/postRegisterApi.js';
+import Toast from '../components/atoms/Toast.jsx';
+
+/**
+ * 회원가입 페이지
+ */
+export default function RegisterPage() {
+  const navigate = useNavigate();
+
+  // 폼 상태
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isSubmitting, isValid },
+  } = useForm({
+    resolver: zodResolver(registerSchema),
+    mode: 'onBlur',
+    defaultValues: {
+      username: '',
+      email: '',
+      password: '',
+      passwordConfirm: '',
+      nick: '',
+    },
+  });
+
+  const password = watch('password');
+  const passwordConfirm = watch('passwordConfirm');
+  const mismatchNow = passwordConfirm && password !== passwordConfirm;
+
+  const onSubmit = async data => {
+    try {
+      const response = await userApi.postRegisterApi(data);
+      console.log(response);
+      Toast({ type: 'basic', message: '회원가입이 완료되었습니다.' });
+      navigate('/login');
+    } catch (error) {
+      console.error(error);
+    }
+    console.log(data);
+  };
+
+  const handleLinkToLogin = () => {
+    navigate('/login');
+  };
+
+  return (
+    <main className={styles.page}>
+      <form
+        className={styles.card}
+        onSubmit={handleSubmit(onSubmit)}
+        noValidate
+      >
+        <div className={styles.header}>
+          <h1 className={styles.title}>회원가입</h1>
+          <p className={styles.subtitle}>MindMeld에 오신 것을 환영합니다</p>
+        </div>
+
+        {/* 사용자명 */}
+        <section className={styles.section}>
+          <label className={styles.label} htmlFor="username">
+            사용자명
+          </label>
+          <Input
+            id="username"
+            placeholder="사용자명을 입력해 주세요"
+            {...register('username')}
+            aria-invalid={!!errors.username}
+            aria-describedby={errors.username ? 'username-error' : undefined}
+          />
+          <div className={styles.errorSlot}>
+            {errors.username && (
+              <p id="username-error" className={styles.error}>
+                {errors.username.message}
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* 이메일 */}
+        <section className={styles.section}>
+          <label className={styles.label} htmlFor="email">
+            이메일
+          </label>
+          <Input
+            id="email"
+            type="email"
+            placeholder="이메일을 입력해 주세요"
+            {...register('email')}
+            aria-invalid={!!errors.email}
+            aria-describedby={errors.email ? 'email-error' : undefined}
+          />
+          <div className={styles.errorSlot}>
+            {errors.email && (
+              <p id="email-error" className={styles.error}>
+                {errors.email.message}
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* 비밀번호 */}
+        <section className={styles.section}>
+          <PasswordInput
+            placeholder="비밀번호를 입력해 주세요"
+            label="비밀번호"
+            autoComplete="off"
+            {...register('password')}
+            aria-invalid={!!errors.password}
+            aria-describedby={errors.password ? 'password-error' : undefined}
+          />
+          <div className={styles.errorSlot}>
+            {errors.password && (
+              <p id="password-error" className={styles.error}>
+                {errors.password.message}
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* 비밀번호 확인 */}
+        <section className={styles.section}>
+          <PasswordInput
+            placeholder="비밀번호를 다시 한 번 입력해 주세요"
+            label="비밀번호 확인"
+            {...register('passwordConfirm')}
+            aria-invalid={!!errors.passwordConfirm || mismatchNow}
+            aria-describedby={
+              errors.passwordConfirm || mismatchNow
+                ? 'passwordConfirm-error'
+                : undefined
+            }
+          />
+          <div className={styles.errorSlot}>
+            {(errors.passwordConfirm || mismatchNow) && (
+              <p id="passwordConfirm-error" className={styles.error}>
+                {errors.passwordConfirm?.message ||
+                  '비밀번호가 일치하지 않습니다'}
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* 닉네임 */}
+        <section className={styles.section}>
+          <label className={styles.label} htmlFor="nick">
+            닉네임
+          </label>
+          <Input
+            id="nick"
+            placeholder="닉네임을 입력해 주세요"
+            {...register('nick')}
+            aria-invalid={!!errors.nick}
+            aria-describedby={errors.nick ? 'nick-error' : undefined}
+          />
+          <div className={styles.errorSlot}>
+            {errors.nick && (
+              <p id="nick-error" className={styles.error}>
+                {errors.nick.message}
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* 회원가입 버튼 */}
+        <div className={styles.cta}>
+          <Button
+            variant="action"
+            size="xl"
+            type="submit"
+            className={styles.submitButton}
+            disabled={isSubmitting || !isValid}
+          >
+            {isSubmitting ? '가입 중...' : '회원가입'}
+          </Button>
+        </div>
+
+        {/* 로그인 링크 */}
+        <div className={styles.loginLink}>
+          <p>
+            이미 계정이 있으신가요?
+            <button
+              type="button"
+              className={styles.linkButton}
+              onClick={handleLinkToLogin}
+            >
+              로그인하기
+            </button>
+          </p>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/src/pages/StudyDetailPage.jsx
+++ b/src/pages/StudyDetailPage.jsx
@@ -1,0 +1,32 @@
+import { useParams } from 'react-router-dom';
+import styles from '../styles/pages/StudyDetailPage.module.css';
+import { useRecentStudyStore } from '../store/recentStudyStore';
+import { useEffect } from 'react';
+import { studyApi } from '../utils/api/study/getStudyApi';
+
+export default function StudyDetailPage() {
+  const { id } = useParams();
+  const addRecentStudy = useRecentStudyStore(state => state.addRecentStudy);
+
+  useEffect(() => {
+    const fetchStudyAndAddToRecent = async () => {
+      try {
+        const data = await studyApi.getStudyDetailApi(id);
+        addRecentStudy(data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchStudyAndAddToRecent();
+  }, [id, addRecentStudy]);
+
+  return (
+    <div className={styles.studyDetailPage}>
+      <h1 className={styles.studyDetailPageTitle}>StudyDetailPage</h1>
+      <span className={styles.studyDetailPageDescription}>
+        스터디 상세페이지 입니다. id : <strong>{id}</strong>
+      </span>
+    </div>
+  );
+}

--- a/src/pages/StudyPage.jsx
+++ b/src/pages/StudyPage.jsx
@@ -5,6 +5,7 @@ import Card from '../components/organisms/Card';
 import Dropdown from '../components/atoms/Dropdown';
 import SearchBar from '../components/molecules/SearchBar';
 import Button from '../components/atoms/Button';
+import { useRecentStudyStore } from '../store/recentStudyStore';
 
 export function StudyPage() {
   const [studyList, setStudyList] = useState([]);
@@ -16,11 +17,19 @@ export function StudyPage() {
     pointOrder: '',
     isActive: true,
   });
+
+  // 최근 조회한 스터디 목록
+  const recentStudies = useRecentStudyStore(state => state.recentStudies);
+  const clearRecentStudies = useRecentStudyStore(
+    state => state.clearRecentStudies,
+  );
+
   useEffect(() => {
     const fetchData = async () => {
       try {
         const data = await studyApi.getStudyApi(studyParams);
         setStudyList(data.studies);
+        console.log(data.studies);
       } catch (error) {
         console.error(error);
       }
@@ -53,23 +62,43 @@ export function StudyPage() {
     setStudyParams({ ...studyParams, limit: studyParams.limit + 6 });
   };
 
+  const handleResetRecentStudies = () => {
+    clearRecentStudies();
+  };
+
   return (
     <main className={styles.studyPageContainer}>
       <section className={styles.studyPageWrapper}>
-        <h1 className={styles.studyPageTitle}>최근 조회한 스터디</h1>
-        {/* 스터디 리스트 */}
-        <div className={styles.studyList}>
-          {studyList.map(study => (
-            <Card
-              key={study.id}
-              preset={'img-08'}
-              nick={study.nick}
-              title={study.name}
-              createdAt={study?.createdAt?.split('T')[0]}
-              description={study.content}
-            />
-          ))}
+        <div className={styles.studyPageWrapperHeader}>
+          <h1 className={styles.studyPageTitle}>최근 조회한 스터디</h1>
+          <Button
+            onClick={handleResetRecentStudies}
+            variant="action"
+            size="ctrl-sm"
+          >
+            초기화
+          </Button>
         </div>
+        {/* 스터디 리스트 */}
+        {recentStudies.length > 0 ? (
+          <div className={styles.studyList}>
+            {recentStudies.map(study => (
+              <Card
+                key={study.id}
+                preset={'img-04'}
+                nick={study.nick}
+                title={study.name}
+                createdAt={study?.createdAt?.split('T')[0]}
+                description={study.content}
+                id={study.id}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className={styles.studyListEmpty}>
+            <p>최근 조회한 스터디가 없습니다.</p>
+          </div>
+        )}
       </section>
 
       {/* 스터디 둘러보기 */}
@@ -90,6 +119,7 @@ export function StudyPage() {
                 points={study?.points[0]?.value || 0}
                 createdAt={study?.createdAt?.split('T')[0]}
                 description={study.content}
+                id={study.id}
               />
             ))}
           </div>

--- a/src/store/recentStudyStore.js
+++ b/src/store/recentStudyStore.js
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export const useRecentStudyStore = create(
+  persist(
+    (set, get) => ({
+      recentStudies: [],
+
+      // 스터디를 최근 조회 목록에 추가
+      addRecentStudy: study => {
+        const { recentStudies } = get();
+
+        // 중복 제거 (같은 id가 있으면 제거)
+        const filteredStudies = recentStudies.filter(
+          item => item.id !== study.id,
+        );
+
+        // 새로운 스터디를 맨 앞에 추가하고 최대 6개까지만 유지
+        const newRecentStudies = [study, ...filteredStudies].slice(0, 6);
+
+        set({ recentStudies: newRecentStudies });
+      },
+
+      // 최근 조회한 스터디 목록 가져오기
+      getRecentStudies: () => {
+        return get().recentStudies;
+      },
+
+      // 모든 최근 조회 목록 초기화
+      clearRecentStudies: () => {
+        set({ recentStudies: [] });
+      },
+    }),
+    {
+      name: 'recent-study-storage', // 로컬스토리지 키 이름
+      getStorage: () => localStorage, // 사용할 스토리지 (localStorage)
+    },
+  ),
+);

--- a/src/styles/components/organisms/Card.module.css
+++ b/src/styles/components/organisms/Card.module.css
@@ -40,7 +40,6 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 100%;
   color: white;
 }
 

--- a/src/styles/components/organisms/Header.module.css
+++ b/src/styles/components/organisms/Header.module.css
@@ -6,6 +6,18 @@
   margin-bottom: 4rem;
 }
 
+.headerButtons {
+  display: flex;
+  align-items: center;
+  gap: 1.6rem;
+}
+
+.headerButton {
+  font-size: 1.6rem;
+  font-weight: 400;
+  color: var(--brand-blue);
+}
+
 @media (max-width: 1024px) {
   .header {
     padding: 2.25rem 4.4rem;

--- a/src/styles/pages/LoginPage.module.css
+++ b/src/styles/pages/LoginPage.module.css
@@ -1,0 +1,356 @@
+/* 기준: 1rem = 10px */
+
+.page {
+  display: grid;
+  place-items: center center;
+  padding: 2.4rem;
+  min-height: 100vh;
+  background: var(--background-primary);
+}
+
+.card {
+  width: 100%;
+  max-width: 48rem;
+  background: #fff;
+  border-radius: 1.2rem;
+  box-shadow: 0 0.4rem 2.4rem rgba(0, 0, 0, 0.08);
+  padding: 4rem 3.2rem 3.2rem;
+  margin: 2.4rem 0;
+}
+
+/* 헤더 섹션 */
+.header {
+  text-align: center;
+  margin-bottom: 4rem;
+  padding-bottom: 2.4rem;
+  border-bottom: 0.1rem solid var(--border-gray);
+}
+
+.title {
+  font-weight: 800;
+  color: var(--text-primary);
+  font-size: 3.2rem;
+  line-height: 1.2;
+  margin: 0 0 1.2rem;
+  background: linear-gradient(135deg, var(--brand-blue) 0%, #4338ca 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.subtitle {
+  font-size: 1.6rem;
+  color: var(--text-gray);
+  font-weight: 400;
+  margin: 0;
+  line-height: 1.4;
+}
+
+/* 섹션 공통 */
+.section {
+  padding-bottom: 1.6rem;
+  margin-bottom: 1.2rem;
+}
+
+.section > * + * {
+  margin-top: 1.2rem;
+}
+
+/* 라벨 */
+.label {
+  display: block;
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: 1.6rem;
+  margin-bottom: 1.2rem;
+}
+
+/* 인풋 통일 규칙 */
+.section :global(input),
+.section :global(textarea),
+.section :global(.wrap) {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* CTA 버튼 영역 */
+.cta {
+  margin: 3.2rem 0 2.4rem;
+  display: flex;
+  justify-content: center;
+}
+
+.submitButton {
+  width: 100%;
+  height: 5.6rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.8rem;
+  font-weight: 600;
+  transition: all 200ms ease;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, var(--brand-blue) 0%, #4338ca 100%);
+}
+
+.submitButton:hover:not(:disabled) {
+  background: linear-gradient(135deg, var(--btn-active) 0%, #3730a3 100%);
+  transform: translateY(-0.2rem);
+  box-shadow: 0 0.8rem 2rem rgba(0, 19, 167, 0.2);
+}
+
+.submitButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+/* 회원가입 링크 */
+.registerLink {
+  text-align: center;
+  margin-top: 2.4rem;
+  padding-top: 2.4rem;
+  border-top: 0.1rem solid var(--border-gray);
+}
+
+.registerLink p {
+  font-size: 1.5rem;
+  color: var(--text-gray);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.linkButton {
+  background: none;
+  border: none;
+  color: var(--brand-blue);
+  font-size: 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  margin-left: 0.4rem;
+  text-decoration: none;
+  transition: all 200ms ease;
+  position: relative;
+}
+
+.linkButton::after {
+  content: '';
+  position: absolute;
+  bottom: -0.2rem;
+  left: 0;
+  width: 0;
+  height: 0.2rem;
+  background: linear-gradient(135deg, var(--brand-blue) 0%, #4338ca 100%);
+  transition: width 200ms ease;
+}
+
+.linkButton:hover {
+  color: var(--brand-blue-dark);
+}
+
+.linkButton:hover::after {
+  width: 100%;
+}
+
+.linkButton:focus-visible {
+  outline: 0.2rem solid var(--brand-blue);
+  outline-offset: 0.2rem;
+  border-radius: 0.4rem;
+}
+
+/* 에러 슬롯: 메시지가 없어도 높이를 미리 잡아 레이아웃 안 밀리게 */
+.errorSlot {
+  min-height: 2.4rem;
+  display: block;
+  margin-top: 0.8rem;
+}
+
+/* 에러 텍스트 */
+.error {
+  margin: 0.4rem 0 0;
+  color: var(--warning-red) !important;
+  font-size: 1.3rem;
+  font-weight: 500;
+  line-height: 1.3;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.error::before {
+  content: '⚠';
+  font-size: 1.2rem;
+}
+
+/* 인풋/텍스트에어리어 빨간 보더 */
+:where(input, textarea)[aria-invalid='true'] {
+  border-color: var(--warning-red) !important;
+  outline-color: var(--warning-red) !important;
+  box-shadow: 0 0 0 0.1rem var(--warning-red) !important;
+}
+
+/* 태블릿 반응형 */
+@media (max-width: 76.8rem) {
+  .page {
+    padding: 2rem;
+  }
+
+  .card {
+    max-width: 100%;
+    padding: 3.2rem 2.4rem;
+    margin: 1.6rem 0;
+    border-radius: 1rem;
+  }
+
+  .header {
+    margin-bottom: 3.2rem;
+    padding-bottom: 2rem;
+  }
+
+  .title {
+    font-size: 2.8rem;
+  }
+
+  .subtitle {
+    font-size: 1.5rem;
+  }
+
+  .label {
+    font-size: 1.5rem;
+  }
+
+  .submitButton {
+    height: 5.2rem;
+    font-size: 1.7rem;
+  }
+
+  .registerLink {
+    margin-top: 2rem;
+    padding-top: 2rem;
+  }
+
+  .registerLink p,
+  .linkButton {
+    font-size: 1.4rem;
+  }
+}
+
+/* 모바일 반응형 */
+@media (max-width: 48rem) {
+  .page {
+    padding: 1.6rem;
+  }
+
+  .card {
+    padding: 2.4rem 2rem;
+    border-radius: 0.8rem;
+  }
+
+  .header {
+    margin-bottom: 2.4rem;
+    padding-bottom: 1.6rem;
+  }
+
+  .title {
+    font-size: 2.4rem;
+  }
+
+  .subtitle {
+    font-size: 1.4rem;
+  }
+
+  .section {
+    margin-bottom: 0.8rem;
+  }
+
+  .label {
+    font-size: 1.4rem;
+    margin-bottom: 1rem;
+  }
+
+  .cta {
+    margin: 2.4rem 0 1.6rem;
+  }
+
+  .submitButton {
+    height: 4.8rem;
+    font-size: 1.6rem;
+  }
+
+  .registerLink {
+    margin-top: 1.6rem;
+    padding-top: 1.6rem;
+  }
+
+  .registerLink p,
+  .linkButton {
+    font-size: 1.3rem;
+  }
+
+  .errorSlot {
+    min-height: 2rem;
+  }
+
+  .error {
+    font-size: 1.2rem;
+  }
+}
+
+/* 접근성 개선 */
+@media (prefers-reduced-motion: reduce) {
+  .submitButton,
+  .linkButton {
+    transition: none;
+  }
+
+  .submitButton:hover:not(:disabled) {
+    transform: none;
+    box-shadow: none;
+  }
+
+  .linkButton::after {
+    transition: none;
+  }
+}
+
+/* 다크모드 지원 */
+@media (prefers-color-scheme: dark) {
+  .card {
+    background: #1a1a1a;
+    box-shadow: 0 0.4rem 2.4rem rgba(0, 0, 0, 0.3);
+  }
+
+  .header {
+    border-bottom-color: #333;
+  }
+
+  .registerLink {
+    border-top-color: #333;
+  }
+
+  .title {
+    background: linear-gradient(135deg, #60a5fa 0%, #a78bfa 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .subtitle,
+  .registerLink p {
+    color: #ccc;
+  }
+
+  .label {
+    color: #fff;
+  }
+}
+
+/* 포커스 스타일 강화 */
+.section :global(input:focus),
+.section :global(textarea:focus) {
+  border-color: var(--brand-blue);
+  box-shadow: 0 0 0 0.3rem rgba(0, 19, 167, 0.1);
+  outline: none;
+}

--- a/src/styles/pages/RegisterPage.module.css
+++ b/src/styles/pages/RegisterPage.module.css
@@ -1,0 +1,281 @@
+/* 기준: 1rem = 10px */
+
+.page {
+  display: grid;
+  place-items: start center;
+  padding: 2.4rem;
+  min-height: 100vh;
+  background: var(--background-primary);
+}
+
+.card {
+  width: 100%;
+  max-width: 60rem;
+  background: #fff;
+  border-radius: 1.2rem;
+  box-shadow: 0 0.4rem 2.4rem rgba(0, 0, 0, 0.08);
+  padding: 3.2rem 2.4rem 2.4rem;
+  margin: 2.4rem 0;
+}
+
+/* 헤더 섹션 */
+.header {
+  text-align: center;
+  margin-bottom: 3.2rem;
+  padding-bottom: 2.4rem;
+  border-bottom: 0.1rem solid var(--border-gray);
+}
+
+.title {
+  font-weight: 800;
+  color: var(--text-primary);
+  font-size: 2.8rem;
+  line-height: 1.2;
+  margin: 0 0 1.2rem;
+}
+
+.subtitle {
+  font-size: 1.6rem;
+  color: var(--text-gray);
+  font-weight: 400;
+  margin: 0;
+  line-height: 1.4;
+}
+
+/* 섹션 공통 */
+.section {
+  padding-bottom: 1.6rem;
+  margin-bottom: 0.8rem;
+}
+
+.section > * + * {
+  margin-top: 1.2rem;
+}
+
+/* 라벨 */
+.label {
+  display: block;
+  color: var(--text-primary);
+  font-weight: 500;
+  font-size: 1.6rem;
+  margin-bottom: 1.2rem;
+}
+
+/* 인풋 통일 규칙 */
+.section :global(input),
+.section :global(textarea),
+.section :global(.wrap) {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* CTA 버튼 영역 */
+.cta {
+  margin: 2.4rem 0 1.6rem;
+  display: flex;
+  justify-content: center;
+}
+
+.submitButton {
+  width: 100%;
+  max-width: 60rem;
+  height: 5.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.8rem;
+  font-weight: 600;
+  transition: all 120ms ease;
+}
+
+.submitButton:hover:not(:disabled) {
+  background: var(--btn-active);
+  transform: translateY(-0.1rem);
+  box-shadow: 0 0.6rem 1.2rem rgba(0, 19, 167, 0.15);
+}
+
+/* 로그인 링크 */
+.loginLink {
+  text-align: center;
+  margin-top: 2.4rem;
+  padding-top: 2.4rem;
+  border-top: 0.1rem solid var(--border-gray);
+}
+
+.loginLink p {
+  font-size: 1.4rem;
+  color: var(--text-gray);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.linkButton {
+  background: none;
+  border: none;
+  color: var(--brand-blue);
+  font-size: 1.4rem;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 0;
+  margin-left: 0.4rem;
+  text-decoration: underline;
+  transition: color 120ms ease;
+}
+
+.linkButton:hover {
+  color: var(--brand-blue-dark);
+}
+
+.linkButton:focus-visible {
+  outline: 0.2rem solid var(--brand-blue);
+  outline-offset: 0.2rem;
+  border-radius: 0.2rem;
+}
+
+/* 에러 슬롯: 메시지가 없어도 높이를 미리 잡아 레이아웃 안 밀리게 */
+.errorSlot {
+  min-height: 2.4rem;
+  display: block;
+  margin-top: 0.8rem;
+}
+
+/* 에러 텍스트 */
+.error {
+  margin: 0.4rem 0 0;
+  color: var(--warning-red) !important;
+  font-size: 1.2rem;
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+/* 인풋/텍스트에어리어 빨간 보더 */
+:where(input, textarea)[aria-invalid='true'] {
+  border-color: var(--warning-red) !important;
+  outline-color: var(--warning-red) !important;
+}
+
+/* 모바일 반응형 */
+@media (max-width: 76.8rem) {
+  .page {
+    padding: 1.6rem;
+  }
+
+  .card {
+    max-width: 100%;
+    padding: 2.4rem 2rem;
+    margin: 1.6rem 0;
+    border-radius: 1rem;
+  }
+
+  .header {
+    margin-bottom: 2.4rem;
+    padding-bottom: 1.6rem;
+  }
+
+  .title {
+    font-size: 2.4rem;
+  }
+
+  .subtitle {
+    font-size: 1.4rem;
+  }
+
+  .label {
+    font-size: 1.4rem;
+  }
+
+  .submitButton {
+    height: 5.2rem;
+    font-size: 1.6rem;
+  }
+
+  .loginLink {
+    margin-top: 2rem;
+    padding-top: 2rem;
+  }
+
+  .loginLink p,
+  .linkButton {
+    font-size: 1.3rem;
+  }
+}
+
+/* 작은 모바일 */
+@media (max-width: 48rem) {
+  .page {
+    padding: 1.2rem;
+  }
+
+  .card {
+    padding: 2rem 1.6rem;
+    border-radius: 0.8rem;
+  }
+
+  .header {
+    margin-bottom: 2rem;
+    padding-bottom: 1.2rem;
+  }
+
+  .title {
+    font-size: 2.2rem;
+  }
+
+  .section {
+    margin-bottom: 0.4rem;
+  }
+
+  .cta {
+    margin: 2rem 0 1.2rem;
+  }
+
+  .submitButton {
+    height: 4.8rem;
+    font-size: 1.5rem;
+  }
+
+  .errorSlot {
+    min-height: 2rem;
+  }
+
+  .error {
+    font-size: 1.1rem;
+  }
+}
+
+/* 접근성 개선 */
+@media (prefers-reduced-motion: reduce) {
+  .submitButton,
+  .linkButton {
+    transition: none;
+  }
+
+  .submitButton:hover:not(:disabled) {
+    transform: none;
+    box-shadow: none;
+  }
+}
+
+/* 다크모드 지원 (필요시) */
+@media (prefers-color-scheme: dark) {
+  .card {
+    background: #1a1a1a;
+    box-shadow: 0 0.4rem 2.4rem rgba(0, 0, 0, 0.3);
+  }
+
+  .header {
+    border-bottom-color: #333;
+  }
+
+  .loginLink {
+    border-top-color: #333;
+  }
+
+  .title {
+    color: #fff;
+  }
+
+  .subtitle,
+  .loginLink p {
+    color: #ccc;
+  }
+}

--- a/src/styles/pages/StudyDetailPage.module.css
+++ b/src/styles/pages/StudyDetailPage.module.css
@@ -1,0 +1,22 @@
+.studyDetailPage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem;
+}
+
+.studyDetailPageTitle {
+  font-size: 2.5rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
+}
+
+.studyDetailPageDescription {
+  font-size: 2rem;
+  color: #666;
+
+  strong {
+    font-weight: 700;
+    color: #0013a7;
+  }
+}

--- a/src/styles/pages/StudyPage.module.css
+++ b/src/styles/pages/StudyPage.module.css
@@ -14,6 +14,13 @@
   padding: 4rem;
 }
 
+.studyPageWrapperHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2.4rem;
+}
+
 .studyListFilter {
   display: flex;
   justify-content: space-between;
@@ -35,6 +42,7 @@
   grid-template-columns: repeat(3, 1fr);
   gap: 2.4rem;
   min-height: 51rem;
+  align-items: flex-start;
 }
 
 .studyPageTitle {

--- a/src/utils/api/study/getStudyApi.js
+++ b/src/utils/api/study/getStudyApi.js
@@ -28,6 +28,17 @@ const getStudyApi = async (params = {}) => {
   }
 };
 
+const getStudyDetailApi = async id => {
+  try {
+    const response = await instance.get(`/api/studies/${id}`);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
 export const studyApi = {
   getStudyApi,
+  getStudyDetailApi,
 };

--- a/src/utils/api/user/postLoginApi.js
+++ b/src/utils/api/user/postLoginApi.js
@@ -1,0 +1,14 @@
+import { instance } from '../axiosInstance.js';
+
+const postLoginApi = async loginData => {
+  try {
+    const response = await instance.post('/api/users/login', loginData);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const userApi = {
+  postLoginApi,
+};

--- a/src/utils/api/user/postRegisterApi.js
+++ b/src/utils/api/user/postRegisterApi.js
@@ -1,0 +1,14 @@
+import { instance } from '../axiosInstance';
+
+const postRegisterApi = async data => {
+  try {
+    const response = await instance.post('/api/users/register', data);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const userApi = {
+  postRegisterApi,
+};

--- a/src/utils/validation/loginSchema.js
+++ b/src/utils/validation/loginSchema.js
@@ -1,0 +1,16 @@
+// src/utils/validation/loginSchema.js
+import { z } from 'zod';
+
+/**
+ * 로그인 폼 유효성 검사 스키마
+ */
+export const loginSchema = z.object({
+  email: z
+    .string()
+    .min(1, '이메일을 입력해 주세요')
+    .email('올바른 이메일 형식을 입력해 주세요'),
+  password: z
+    .string()
+    .min(1, '비밀번호를 입력해 주세요')
+    .min(8, '비밀번호는 최소 6자 이상이어야 합니다'),
+});

--- a/src/utils/validation/registerSchema.js
+++ b/src/utils/validation/registerSchema.js
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+export const registerSchema = z
+  .object({
+    username: z
+      .string()
+      .min(1, '사용자명을 입력해주세요')
+      .min(3, '사용자명은 3자 이상 입력해주세요')
+      .max(20, '사용자명은 20자 이하로 입력해주세요'),
+
+    email: z
+      .string()
+      .min(1, '이메일을 입력해주세요')
+      .email('올바른 이메일 형식을 입력해주세요'),
+
+    password: z
+      .string()
+      .min(1, '비밀번호를 입력해주세요')
+      .min(6, '비밀번호는 6자 이상이어야 합니다')
+      .regex(
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d@$!%*?&]{6,}$/,
+        '비밀번호는 영문 대문자, 소문자, 숫자를 포함하여 6자 이상이어야 합니다',
+      ),
+
+    passwordConfirm: z.string().min(1, '비밀번호 확인을 입력해주세요'),
+
+    nick: z
+      .string()
+      .min(1, '닉네임을 입력해주세요')
+      .min(2, '닉네임은 2자 이상 입력해주세요')
+      .max(10, '닉네임은 10자 이하로 입력해주세요'),
+  })
+  .refine(data => data.password === data.passwordConfirm, {
+    message: '비밀번호가 일치하지 않습니다',
+    path: ['passwordConfirm'], // 에러가 표시될 필드
+  });


### PR DESCRIPTION

### 반영 브랜치
ex) feat/register -> dev

### 변경 사항
- [x] 로그인 페이지와 회원가입 페이지 컴포넌트 생성
- [x] 로그인 및 회원가입 폼 유효성 검사 스키마 추가
- [x] 최근 조회한 스터디 관리 기능을 위한 Zustand 스토어 추가
- [x] 스터디 상세 페이지 및 관련 API 호출 기능 추가
- [x] 헤더에 로그인 및 회원가입 링크 추가
- [x] CSS 스타일 및 레이아웃 개선

### 테스트 결과
- 로그인, 회원가입 정상화 가능
- 메인페이지 검색기능, 필터기능, 최근 조회한 스터디 조회 가능

### 참고 사항 (Optional)
- 유효성 검사 프론트, 벡엔드 맞춰서 합의를 해야함.
- 토큰 저장은 아직 진행하지 않음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 회원가입·로그인 페이지와 라우팅 추가, 헤더에 링크 노출
  - 폼 유효성 검증·에러 표시 및 토스트 알림 지원
  - 스터디 상세 페이지 추가, 카드 클릭 시 상세로 이동
  - 최근 본 스터디 저장·표시 및 초기화 기능
  - 토스트에 basic 타입과 커스텀 메시지 지원
- Style
  - 로그인·회원가입·상세·목록 페이지 스타일 추가(반응형/다크모드), 헤더 버튼 스타일
  - 카드 콘텐츠 높이 조정으로 레이아웃 안정화
- Chores
  - 폼/상태관리/검증 라이브러리 의존성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->