### PR TITLE
feat: 프로필 페이지 및 사용자 정보 수정 기능 추가

### DIFF
--- a/src/components/organisms/Header.jsx
+++ b/src/components/organisms/Header.jsx
@@ -53,7 +53,11 @@ export function Header() {
       <div className={styles.headerButtons}>
         {isLoggedIn ? (
           <div>
-            <span className={styles.userName}>{user.username + '님 환영'}</span>
+            <Link to="/profile">
+              <span className={styles.userName}>
+                {user.username + '님 환영'}
+              </span>
+            </Link>
             <Button
               variant="secondary"
               size="ctrl-sm"

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -15,6 +15,7 @@ import RegisterPage from './pages/RegisterPage';
 import LoginPage from './pages/LoginPage';
 import StudyDetailPage from './pages/StudyDetailPage';
 import { useAuthStore } from './store/authStore';
+import ProfilePage from './pages/ProfilePage';
 
 export function App() {
   const { initialize } = useAuthStore();
@@ -35,6 +36,7 @@ export function App() {
             <Route path="/study/:id" element={<StudyDetailPage />} />
             <Route path="/register" element={<RegisterPage />} />
             <Route path="/login" element={<LoginPage />} />
+            <Route path="/profile" element={<ProfilePage />} />
           </Route>
           <Route path="*" element={<NotFoundPage />} />
         </Routes>

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -1,0 +1,225 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import Input from '../components/atoms/Input.jsx';
+import Button from '../components/atoms/Button.jsx';
+import PasswordInput from '../components/molecules/PasswordInput.jsx';
+import { profileSchema } from '../utils/validation/profileSchema.js';
+import { useAuthStore } from '../store/authStore.js';
+import { getUsersApi } from '../utils/api/user/getUsersApi.js';
+import { patchUserProfileApi } from '../utils/api/user/patchUserProfileApi.js';
+import styles from '../styles/pages/ProfilePage.module.css';
+
+/**
+ * 프로필 수정 페이지
+ */
+export default function ProfilePage() {
+  const navigate = useNavigate();
+  const { isLoggedIn, logout, updateUser } = useAuthStore();
+
+  // 폼 상태 관리
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors, isSubmitting, isValid },
+  } = useForm({
+    resolver: zodResolver(profileSchema),
+    mode: 'onBlur',
+    defaultValues: {
+      username: '',
+      nick: '',
+      password: '',
+      passwordConfirm: '',
+    },
+  });
+
+  const password = watch('password');
+  const passwordConfirm = watch('passwordConfirm');
+  const mismatchNow = passwordConfirm && password !== passwordConfirm;
+
+  // 사용자 정보 로드
+  useEffect(() => {
+    const loadUserInfo = async () => {
+      if (!isLoggedIn) {
+        navigate('/login');
+        return;
+      }
+
+      try {
+        const userData = await getUsersApi();
+        console.log(userData);
+        if (userData?.data) {
+          setValue('username', userData.data.username || '');
+          setValue('nick', userData.data.nick || '');
+        }
+      } catch (error) {
+        console.error('사용자 정보 로드 실패:', error);
+        // 인증 오류 시 로그아웃 처리
+        if (error.response?.status === 401) {
+          await logout();
+          navigate('/login');
+        }
+      }
+    };
+
+    loadUserInfo();
+  }, [isLoggedIn, navigate, setValue, logout]);
+
+  // 프로필 수정 처리
+  const onSubmit = async data => {
+    try {
+      // 빈 비밀번호는 제거하고 전송
+      const profileData = {
+        username: data.username,
+        nick: data.nick,
+      };
+
+      if (data.password && data.password.trim() !== '') {
+        profileData.password = data.password;
+      }
+
+      const response = await patchUserProfileApi(profileData);
+
+      // 성공 시 사용자 정보 업데이트
+      if (response?.data) {
+        updateUser(response.data);
+      }
+
+      // 성공 시 메인 페이지로 이동
+      navigate('/');
+    } catch (error) {
+      console.error('프로필 수정 실패:', error);
+    }
+  };
+
+  // 취소 버튼 클릭
+  const handleCancel = () => {
+    navigate(-1); // 이전 페이지로 돌아가기
+  };
+
+  return (
+    <main className={styles.page}>
+      <form
+        className={styles.card}
+        onSubmit={handleSubmit(onSubmit)}
+        noValidate
+      >
+        <div className={styles.header}>
+          <h1 className={styles.title}>프로필 수정</h1>
+          <p className={styles.subtitle}>회원 정보를 수정하실 수 있습니다</p>
+        </div>
+
+        {/* 사용자명 */}
+        <section className={styles.section}>
+          <label className={styles.label} htmlFor="username">
+            사용자명
+          </label>
+          <Input
+            id="username"
+            placeholder="사용자명을 입력해 주세요"
+            {...register('username')}
+            aria-invalid={!!errors.username}
+            aria-describedby={errors.username ? 'username-error' : undefined}
+          />
+          <div className={styles.errorSlot}>
+            {errors.username && (
+              <p id="username-error" className={styles.error}>
+                {errors.username.message}
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* 닉네임 */}
+        <section className={styles.section}>
+          <label className={styles.label} htmlFor="nick">
+            닉네임
+          </label>
+          <Input
+            id="nick"
+            placeholder="닉네임을 입력해 주세요"
+            {...register('nick')}
+            aria-invalid={!!errors.nick}
+            aria-describedby={errors.nick ? 'nick-error' : undefined}
+          />
+          <div className={styles.errorSlot}>
+            {errors.nick && (
+              <p id="nick-error" className={styles.error}>
+                {errors.nick.message}
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* 새 비밀번호 */}
+        <section className={styles.section}>
+          <PasswordInput
+            placeholder="새 비밀번호 (변경하지 않으려면 비워두세요)"
+            label="새 비밀번호"
+            autoComplete="new-password"
+            {...register('password')}
+            aria-invalid={!!errors.password}
+            aria-describedby={errors.password ? 'password-error' : undefined}
+          />
+          <div className={styles.errorSlot}>
+            {errors.password && (
+              <p id="password-error" className={styles.error}>
+                {errors.password.message}
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* 새 비밀번호 확인 */}
+        {password && password.trim() !== '' && (
+          <section className={styles.section}>
+            <PasswordInput
+              placeholder="새 비밀번호를 다시 한 번 입력해 주세요"
+              label="새 비밀번호 확인"
+              {...register('passwordConfirm')}
+              aria-invalid={!!errors.passwordConfirm || mismatchNow}
+              aria-describedby={
+                errors.passwordConfirm || mismatchNow
+                  ? 'passwordConfirm-error'
+                  : undefined
+              }
+            />
+            <div className={styles.errorSlot}>
+              {(errors.passwordConfirm || mismatchNow) && (
+                <p id="passwordConfirm-error" className={styles.error}>
+                  {errors.passwordConfirm?.message ||
+                    '비밀번호가 일치하지 않습니다'}
+                </p>
+              )}
+            </div>
+          </section>
+        )}
+
+        {/* 버튼 영역 */}
+        <div className={styles.buttonGroup}>
+          <Button
+            variant="outline"
+            size="lg"
+            type="button"
+            onClick={handleCancel}
+            className={styles.cancelButton}
+          >
+            취소
+          </Button>
+          <Button
+            variant="action"
+            size="lg"
+            type="submit"
+            className={styles.submitButton}
+            disabled={isSubmitting || !isValid}
+          >
+            {isSubmitting ? '수정 중...' : '수정하기'}
+          </Button>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/src/store/authStore.js
+++ b/src/store/authStore.js
@@ -61,4 +61,11 @@ export const useAuthStore = create(set => ({
       });
     }
   },
+
+  updateUser: userData => {
+    set(state => ({
+      ...state,
+      user: userData,
+    }));
+  },
 }));

--- a/src/styles/pages/ProfilePage.module.css
+++ b/src/styles/pages/ProfilePage.module.css
@@ -1,0 +1,370 @@
+/* 기준: 1rem = 10px */
+
+.page {
+  display: grid;
+  place-items: start center;
+  padding: 2.4rem;
+  min-height: 100vh;
+  background: var(--background-primary);
+}
+
+.card {
+  width: 100%;
+  max-width: 60rem;
+  background: #fff;
+  border-radius: 1.2rem;
+  box-shadow: 0 0.4rem 2.4rem rgba(0, 0, 0, 0.08);
+  padding: 3.2rem 2.4rem 2.4rem;
+  margin: 2.4rem 0;
+}
+
+/* 헤더 섹션 */
+.header {
+  text-align: center;
+  margin-bottom: 3.2rem;
+  padding-bottom: 2.4rem;
+  border-bottom: 0.1rem solid var(--border-gray);
+}
+
+.title {
+  font-weight: 800;
+  color: var(--text-primary);
+  font-size: 2.8rem;
+  line-height: 1.2;
+  margin: 0 0 1.2rem;
+  background: linear-gradient(135deg, var(--brand-blue) 0%, #4338ca 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.subtitle {
+  font-size: 1.6rem;
+  color: var(--text-gray);
+  font-weight: 400;
+  margin: 0;
+  line-height: 1.4;
+}
+
+/* 섹션 공통 */
+.section {
+  padding-bottom: 1.6rem;
+  margin-bottom: 0.8rem;
+}
+
+.section > * + * {
+  margin-top: 1.2rem;
+}
+
+/* 라벨 */
+.label {
+  display: block;
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: 1.6rem;
+  margin-bottom: 1.2rem;
+}
+
+/* 인풋 통일 규칙 */
+.section :global(input),
+.section :global(textarea),
+.section :global(.wrap) {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* 버튼 그룹 */
+.buttonGroup {
+  display: flex;
+  gap: 1.2rem;
+  margin: 3.2rem 0 2.4rem;
+  justify-content: center;
+}
+
+.cancelButton,
+.submitButton {
+  flex: 1;
+  height: 5.2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.6rem;
+  font-weight: 600;
+  transition: all 200ms ease;
+  border-radius: 1rem;
+  max-width: 20rem;
+}
+
+.cancelButton {
+  color: var(--text-gray);
+  border: 0.2rem solid var(--border-gray);
+  background: transparent;
+}
+
+.cancelButton:hover:not(:disabled) {
+  border-color: var(--text-gray);
+  color: var(--text-primary);
+  transform: translateY(-0.1rem);
+  box-shadow: 0 0.4rem 0.8rem rgba(0, 0, 0, 0.1);
+}
+
+.submitButton {
+  background: linear-gradient(135deg, var(--brand-blue) 0%, #4338ca 100%);
+  color: white;
+  border: none;
+}
+
+.submitButton:hover:not(:disabled) {
+  background: linear-gradient(135deg, var(--btn-active) 0%, #3730a3 100%);
+  transform: translateY(-0.1rem);
+  box-shadow: 0 0.6rem 1.2rem rgba(0, 19, 167, 0.2);
+}
+
+.submitButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+/* 로그아웃 섹션 */
+.logoutSection {
+  text-align: center;
+  margin-top: 2.4rem;
+  padding-top: 2.4rem;
+  border-top: 0.1rem solid var(--border-gray);
+}
+
+.logoutButton {
+  background: none;
+  color: var(--warning-red);
+  border: 0.2rem solid var(--warning-red);
+  font-size: 1.4rem;
+  font-weight: 500;
+  padding: 1rem 2rem;
+  border-radius: 0.8rem;
+  transition: all 200ms ease;
+  cursor: pointer;
+}
+
+.logoutButton:hover:not(:disabled) {
+  background: var(--warning-red);
+  color: white;
+  transform: translateY(-0.1rem);
+  box-shadow: 0 0.4rem 0.8rem rgba(220, 38, 127, 0.2);
+}
+
+.logoutButton:focus-visible {
+  outline: 0.2rem solid var(--warning-red);
+  outline-offset: 0.2rem;
+}
+
+/* 에러 슬롯: 메시지가 없어도 높이를 미리 잡아 레이아웃 안 밀리게 */
+.errorSlot {
+  min-height: 2.4rem;
+  display: block;
+  margin-top: 0.8rem;
+}
+
+/* 에러 텍스트 */
+.error {
+  margin: 0.4rem 0 0;
+  color: var(--warning-red) !important;
+  font-size: 1.2rem;
+  font-weight: 500;
+  line-height: 1.3;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.error::before {
+  content: '⚠';
+  font-size: 1.1rem;
+}
+
+/* 인풋/텍스트에어리어 빨간 보더 */
+:where(input, textarea)[aria-invalid='true'] {
+  border-color: var(--warning-red) !important;
+  outline-color: var(--warning-red) !important;
+  box-shadow: 0 0 0 0.1rem var(--warning-red) !important;
+}
+
+/* 태블릿 반응형 */
+@media (max-width: 76.8rem) {
+  .page {
+    padding: 2rem;
+  }
+
+  .card {
+    max-width: 100%;
+    padding: 2.4rem 2rem;
+    margin: 1.6rem 0;
+    border-radius: 1rem;
+  }
+
+  .header {
+    margin-bottom: 2.4rem;
+    padding-bottom: 1.6rem;
+  }
+
+  .title {
+    font-size: 2.4rem;
+  }
+
+  .subtitle {
+    font-size: 1.4rem;
+  }
+
+  .label {
+    font-size: 1.4rem;
+  }
+
+  .buttonGroup {
+    margin: 2.4rem 0 1.6rem;
+    gap: 1rem;
+  }
+
+  .cancelButton,
+  .submitButton {
+    height: 4.8rem;
+    font-size: 1.5rem;
+  }
+
+  .logoutSection {
+    margin-top: 2rem;
+    padding-top: 2rem;
+  }
+
+  .logoutButton {
+    font-size: 1.3rem;
+  }
+}
+
+/* 모바일 반응형 */
+@media (max-width: 48rem) {
+  .page {
+    padding: 1.2rem;
+  }
+
+  .card {
+    padding: 2rem 1.6rem;
+    border-radius: 0.8rem;
+  }
+
+  .header {
+    margin-bottom: 2rem;
+    padding-bottom: 1.2rem;
+  }
+
+  .title {
+    font-size: 2.2rem;
+  }
+
+  .section {
+    margin-bottom: 0.4rem;
+  }
+
+  .buttonGroup {
+    flex-direction: column;
+    margin: 2rem 0 1.2rem;
+    gap: 0.8rem;
+  }
+
+  .cancelButton,
+  .submitButton {
+    max-width: 100%;
+    height: 4.4rem;
+    font-size: 1.4rem;
+  }
+
+  .logoutSection {
+    margin-top: 1.6rem;
+    padding-top: 1.6rem;
+  }
+
+  .logoutButton {
+    font-size: 1.2rem;
+    padding: 0.8rem 1.6rem;
+  }
+
+  .errorSlot {
+    min-height: 2rem;
+  }
+
+  .error {
+    font-size: 1.1rem;
+  }
+}
+
+/* 접근성 개선 */
+@media (prefers-reduced-motion: reduce) {
+  .cancelButton,
+  .submitButton,
+  .logoutButton {
+    transition: none;
+  }
+
+  .cancelButton:hover:not(:disabled),
+  .submitButton:hover:not(:disabled),
+  .logoutButton:hover:not(:disabled) {
+    transform: none;
+    box-shadow: none;
+  }
+}
+
+/* 다크모드 지원 */
+@media (prefers-color-scheme: dark) {
+  .card {
+    background: #1a1a1a;
+    box-shadow: 0 0.4rem 2.4rem rgba(0, 0, 0, 0.3);
+  }
+
+  .header {
+    border-bottom-color: #333;
+  }
+
+  .logoutSection {
+    border-top-color: #333;
+  }
+
+  .title {
+    background: linear-gradient(135deg, #60a5fa 0%, #a78bfa 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+  }
+
+  .subtitle {
+    color: #ccc;
+  }
+
+  .label {
+    color: #fff;
+  }
+
+  .cancelButton {
+    color: #ccc;
+    border-color: #444;
+  }
+
+  .cancelButton:hover:not(:disabled) {
+    border-color: #666;
+    color: #fff;
+  }
+}
+
+/* 포커스 스타일 강화 */
+.section :global(input:focus),
+.section :global(textarea:focus) {
+  border-color: var(--brand-blue);
+  box-shadow: 0 0 0 0.3rem rgba(0, 19, 167, 0.1);
+  outline: none;
+}
+
+/* 버튼 포커스 스타일 */
+.cancelButton:focus-visible,
+.submitButton:focus-visible {
+  outline: 0.2rem solid var(--brand-blue);
+  outline-offset: 0.2rem;
+}

--- a/src/utils/api/user/patchUserProfileApi.js
+++ b/src/utils/api/user/patchUserProfileApi.js
@@ -1,0 +1,11 @@
+import { instance } from '../axiosInstance';
+
+export const patchUserProfileApi = async profileData => {
+  try {
+    const response = await instance.patch('/api/users/me', profileData);
+    return response.data;
+  } catch (error) {
+    console.error('프로필 수정 실패:', error);
+    throw error;
+  }
+};

--- a/src/utils/validation/profileSchema.js
+++ b/src/utils/validation/profileSchema.js
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+export const profileSchema = z
+  .object({
+    username: z
+      .string()
+      .min(1, '사용자명을 입력해주세요')
+      .min(3, '사용자명은 3자 이상 입력해주세요')
+      .max(20, '사용자명은 20자 이하로 입력해주세요'),
+
+    nick: z
+      .string()
+      .min(1, '닉네임을 입력해주세요')
+      .max(10, '닉네임은 10자 이하로 입력해주세요'),
+
+    password: z
+      .string()
+      .optional()
+      .refine(
+        value => {
+          // 비밀번호가 입력되지 않은 경우 (빈 문자열 또는 undefined) 유효
+          if (!value || value === '') return true;
+          // 비밀번호가 입력된 경우 유효성 검사
+          return /^(?=.*[a-z])(?=.*\d)[a-z\d@$!%*?&]{8,30}$/.test(value);
+        },
+        {
+          message:
+            '비밀번호는 영문 소문자, 숫자를 포함하여 8자 이상 30자 이하로 입력해주세요',
+        },
+      ),
+
+    passwordConfirm: z.string().optional(),
+  })
+  .refine(
+    data => {
+      // 비밀번호가 입력되지 않은 경우 확인 비밀번호도 검증하지 않음
+      if (!data.password || data.password === '') return true;
+      // 비밀번호가 입력된 경우 확인 비밀번호와 일치해야 함
+      return data.password === data.passwordConfirm;
+    },
+    {
+      message: '비밀번호가 일치하지 않습니다',
+      path: ['passwordConfirm'],
+    },
+  );


### PR DESCRIPTION
### 반영 브랜치
ex) feat/profile -> dev

### 변경 사항
- [x] ProfilePage 컴포넌트 생성 및 사용자 정보 수정 기능 구현
- [x] 헤더에서 사용자 이름 클릭 시 프로필 페이지로 이동하도록 수정
- [x] 사용자 프로필 수정 시 유효성 검사를 위한 Zod 스키마 추가
- [x] Zustand 스토어에 사용자 정보 업데이트 기능 추가
- [x] 프로필 수정 API 호출을 위한 함수 구현 및 에러 처리 추가

### 테스트 결과
- 프로필 변경 정상적 동작 완료
- 프로필 완료시 메인으로 이동
- 헤더에 닉네임도 변경 확인 완료

### 참고 사항 (Optional)

<img width="1335" height="938" alt="image" src="https://github.com/user-attachments/assets/32f304df-f9cf-48e2-8773-e97595355f26" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 프로필 페이지 추가: 사용자명·닉네임 수정, 선택적 비밀번호 변경, 실시간 유효성 검사와 오류 메시지, 저장/취소 지원. 비로그인 시 로그인 페이지로 이동, 저장 성공 시 홈으로 이동. 헤더의 환영 문구를 클릭해 프로필 페이지로 이동 가능.
- 스타일
  - 프로필 페이지에 반응형·다크 모드 지원과 접근성 개선(포커스 표시, 에러 상태, 버튼 상태) 스타일 적용.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->