### PR TITLE
feat: 로그인 상태 관리 개선 및 API 응답 처리 안전성 강화

### DIFF
--- a/src/components/organisms/Header.jsx
+++ b/src/components/organisms/Header.jsx
@@ -16,7 +16,6 @@ export function Header() {
   const isMainPage = location.pathname === '/';
 
   const { isLoggedIn, user, logout } = useAuthStore();
-  console.log(isLoggedIn, user);
 
   const handleLogout = async () => {
     await logout();

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -22,7 +22,11 @@ export function App() {
   const { initialize } = useAuthStore();
 
   useEffect(() => {
-    initialize();
+    // localStorage에 로그인 기록이 있을 때만 initialize 실행
+    const hasLoggedIn = localStorage.getItem('hasLoggedIn');
+    if (hasLoggedIn) {
+      initialize();
+    }
   }, [initialize]);
 
   return (

--- a/src/store/authStore.js
+++ b/src/store/authStore.js
@@ -27,7 +27,7 @@ export const useAuthStore = create(set => ({
   login: async data => {
     try {
       const response = await postLoginApi(data);
-      console.log('로그인 성공:', response);
+      console.log('로그인 성공');
 
       localStorage.setItem('hasLoggedIn', 'true');
 

--- a/src/store/authStore.js
+++ b/src/store/authStore.js
@@ -10,17 +10,17 @@ export const useAuthStore = create(set => ({
 
   initialize: async () => {
     try {
-      const { user } = await postRefreshApi();
+      const result = await postRefreshApi();
 
-      if (user) {
-        set({ isLoggedIn: true, user, isInitialized: true });
+      if (result?.user) {
+        set({ isLoggedIn: true, user: result.user, isInitialized: true });
       } else {
         set({ isLoggedIn: false, user: null, isInitialized: true });
       }
     } catch (error) {
+      localStorage.removeItem('hasLoggedIn');
       console.error('초기화 실패:', error);
       set({ isLoggedIn: false, user: null, isInitialized: true });
-      throw error;
     }
   },
 
@@ -28,6 +28,8 @@ export const useAuthStore = create(set => ({
     try {
       const response = await postLoginApi(data);
       console.log('로그인 성공:', response);
+
+      localStorage.setItem('hasLoggedIn', 'true');
 
       set({
         isLoggedIn: true,
@@ -46,6 +48,8 @@ export const useAuthStore = create(set => ({
       // 서버에 로그아웃 요청을 보내 서버 세션을 무효화합니다.
       const response = await postLogoutApi();
       console.log('로그아웃 성공:', response);
+
+      localStorage.removeItem('hasLoggedIn');
       // 클라이언트 상태 초기화
       set({
         isLoggedIn: false,
@@ -55,6 +59,7 @@ export const useAuthStore = create(set => ({
     } catch (error) {
       console.error('로그아웃 실패:', error);
       // 서버 로그아웃 실패해도 클라이언트 상태는 초기화
+      localStorage.removeItem('hasLoggedIn');
       set({
         isLoggedIn: false,
         user: null,

--- a/src/utils/api/user/postRefreshApi.js
+++ b/src/utils/api/user/postRefreshApi.js
@@ -7,7 +7,7 @@ export const postRefreshApi = async () => {
     });
 
     // 응답 데이터 구조 안전하게 접근
-    const responseData = response.data?.data;
+    const responseData = response.data?.data || response.data;
 
     if (!responseData) {
       console.warn('토큰 갱신 응답에 데이터가 없습니다.');
@@ -24,15 +24,15 @@ export const postRefreshApi = async () => {
     // Authorization 헤더 설정
     instance.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
 
-    console.log('refresh 성공:', response.data);
+    console.log('refresh 성공');
 
     return { accessToken, user };
   } catch (error) {
-    if (error.response?.status === 401) {
+    if (error.response?.status === 401 || error.response?.status === 403) {
+      delete instance.defaults.headers.common['Authorization']; // 401 (권한 없음) , 403 (권한 부족으로 인해 접근을 거부한 상태) 에러 시 헤더 제거
       return null;
     }
     console.error(error);
-    delete instance.defaults.headers.common['Authorization'];
 
     // 에러를 throw하지 않고 null 반환
     return null;

--- a/src/utils/api/user/postRefreshApi.js
+++ b/src/utils/api/user/postRefreshApi.js
@@ -2,17 +2,39 @@ import { instance } from '../axiosInstance.js';
 
 export const postRefreshApi = async () => {
   try {
-    const response = await instance.post('/api/users/refresh');
-    const { accessToken, user } = response.data.data;
+    const response = await instance.post('/api/users/refresh', null, {
+      headers: { Authorization: null },
+    });
+
+    // 응답 데이터 구조 안전하게 접근
+    const responseData = response.data?.data;
+
+    if (!responseData) {
+      console.warn('토큰 갱신 응답에 데이터가 없습니다.');
+      return null;
+    }
+
+    const { accessToken, user } = responseData;
+
+    if (!accessToken) {
+      console.warn('응답에 액세스 토큰이 포함되지 않았습니다.');
+      return null;
+    }
+
+    // Authorization 헤더 설정
     instance.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
 
     console.log('refresh 성공:', response.data);
 
     return { accessToken, user };
   } catch (error) {
+    if (error.response?.status === 401) {
+      return null;
+    }
     console.error(error);
     delete instance.defaults.headers.common['Authorization'];
 
-    throw error;
+    // 에러를 throw하지 않고 null 반환
+    return null;
   }
 };


### PR DESCRIPTION
### 반영 브랜치
ex) fix/emoji -> develop

### 변경 사항
- [x] localStorage를 사용하여 로그인 기록 관리 추가
- [x] 초기화 시 로그인 기록이 있을 경우에만 initialize 함수 실행
- [x] postRefreshApi에서 응답 데이터 구조 안전하게 접근 및 에러 처리 개선
- [x] 로그아웃 시 localStorage에서 로그인 기록 제거

### 테스트 결과
- 첫 진입 시 401 에러가 뜨지 않도록 함, 약간 불안정한 경우가 있음.

### 참고 사항 (Optional)
- 다른 방법이 있을 거 같지만 임시방편으로 로컬 스토리지에 hasLogined  'true' 값을 적용하여 로그인 여부를 체크했습니다.
- 다른 방법이 있을 시 삭제하는 방향으로 진행하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 로그인 성공 시 상태를 로컬에 저장하고, 저장된 상태가 있을 때만 앱 초기화를 수행.
- 버그 수정
  - 세션 갱신 응답 검증 강화로 불완전한 응답 처리 안정화.
  - 401/403 등 권한 실패를 안전하게 처리해 예외 전파 및 비정상 종료 감소.
- 리팩터링
  - 인증 헤더 설정/해제 흐름과 초기화 로직 오류 처리 일관화.
- 기타
  - 불필요한 콘솔 로그 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->