### PR TITLE
fix: 스터디 페이지 정렬 기능 픽스 (포인트 순)

### DIFF
--- a/src/components/atoms/Dropdown.jsx
+++ b/src/components/atoms/Dropdown.jsx
@@ -1,16 +1,9 @@
 import React, { useState, useRef, useEffect } from 'react';
 import styles from '../../styles/components/atoms/Dropdown.module.css';
 
-const Dropdown = ({ onChange, value = 'recent' }) => {
+const Dropdown = ({ onChange, value = 'recent', options = [] }) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef(null);
-
-  const options = [
-    { value: 'recent', label: '최근순' },
-    { value: 'old', label: '오래된 순' },
-    { value: 'desc', label: '많은 포인트 순' },
-    { value: 'asc', label: '적은 포인트 순' },
-  ];
 
   const selectedOption =
     options.find(option => option.value === value) || options[0];

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -41,5 +41,4 @@ export function App() {
   );
 }
 
-const root = createRoot(document.getElementById('root'));
-root.render(<App />);
+createRoot(document.getElementById('root')).render(<App />);

--- a/src/pages/StudyPage.jsx
+++ b/src/pages/StudyPage.jsx
@@ -7,14 +7,22 @@ import SearchBar from '../components/molecules/SearchBar';
 import Button from '../components/atoms/Button';
 import { useRecentStudyStore } from '../store/recentStudyStore';
 
+const MORE_LIMIT = 6;
+
+const options = [
+  { value: 'recent', label: '최근순' },
+  { value: 'old', label: '오래된 순' },
+  { value: 'points_desc', label: '많은 포인트 순' },
+  { value: 'points_asc', label: '적은 포인트 순' },
+];
+
 export function StudyPage() {
   const [studyList, setStudyList] = useState([]);
   const [studyParams, setStudyParams] = useState({
-    recentOrder: 'recent',
     offset: 0,
     limit: 6,
     keyword: '',
-    pointOrder: '',
+    sort: 'recent',
     isActive: true,
   });
 
@@ -42,24 +50,14 @@ export function StudyPage() {
   };
 
   const handleDropdownChange = value => {
-    if (value === 'recent' || value === 'old') {
-      setStudyParams({
-        ...studyParams,
-        recentOrder: value,
-        pointOrder: '',
-      });
-    }
-    if (value === 'desc' || value === 'asc') {
-      setStudyParams({
-        ...studyParams,
-        recentOrder: '',
-        pointOrder: value,
-      });
-    }
+    setStudyParams({
+      ...studyParams,
+      sort: value,
+    });
   };
 
   const handleStudyMore = () => {
-    setStudyParams({ ...studyParams, limit: studyParams.limit + 6 });
+    setStudyParams({ ...studyParams, limit: studyParams.limit + MORE_LIMIT });
   };
 
   const handleResetRecentStudies = () => {
@@ -83,39 +81,22 @@ export function StudyPage() {
         {recentStudies.length > 0 ? (
           <div className={styles.studyList}>
             {recentStudies.map(study => {
-              // study.img 값을 올바른 프리셋 키로 매핑
-              const mapToPresetKey = (imgValue) => {
-                if (!imgValue) return 'img-01'; // 기본값
-                
-                // 백엔드에서 오는 경로를 프리셋 키로 매핑
-                const pathToKeyMapping = {
-                  '/assets/images/card-bg-color-01.svg': 'img-01',
-                  '/assets/images/card-bg-color-02.svg': 'img-02',
-                  '/assets/images/card-bg-color-03.svg': 'img-03',
-                  '/assets/images/card-bg-color-04.svg': 'img-04',
-                  '/assets/images/card-bg-01.svg': 'img-05',
-                  '/assets/images/card-bg-02.svg': 'img-06',
-                  '/assets/images/card-bg-03.svg': 'img-07',
-                  '/assets/images/card-bg-04.svg': 'img-08',
-                };
-                
-                return pathToKeyMapping[imgValue] || 'img-01';
-              };
-              
               return (
                 <Card
                   key={study.id}
-                  preset={mapToPresetKey(study.img)}
+                  preset={study.img}
                   nick={study.nick}
                   title={study.name}
                   points={study.point || 0}
                   createdAt={study?.createdAt?.split('T')[0]}
                   description={study.content}
                   id={study.id}
-                  emojiData={study.studyEmojis?.map(item => ({
-                    emoji: item.emoji?.symbol || item.symbol || '🔥',
-                    count: item.count || 0,
-                  })) || []}
+                  emojiData={
+                    study.studyEmojis?.map(item => ({
+                      emoji: item.emoji?.symbol || item.symbol || '🔥',
+                      count: item.count || 0,
+                    })) || []
+                  }
                 />
               );
             })}
@@ -134,47 +115,29 @@ export function StudyPage() {
           <SearchBar onSubmit={handleSubmit} />
           <Dropdown
             onChange={handleDropdownChange}
-            value={
-              studyParams.recentOrder || studyParams.pointOrder || 'recent'
-            }
+            value={studyParams.sort || 'recent'}
+            options={options}
           />
         </div>
         {studyList.length > 0 ? (
           <div className={styles.studyList}>
             {studyList.map(study => {
-              // study.img 값을 올바른 프리셋 키로 매핑
-              const mapToPresetKey = (imgValue) => {
-                if (!imgValue) return 'img-01'; // 기본값
-                
-                // 백엔드에서 오는 경로를 프리셋 키로 매핑
-                const pathToKeyMapping = {
-                  '/assets/images/card-bg-color-01.svg': 'img-01',
-                  '/assets/images/card-bg-color-02.svg': 'img-02',
-                  '/assets/images/card-bg-color-03.svg': 'img-03',
-                  '/assets/images/card-bg-color-04.svg': 'img-04',
-                  '/assets/images/card-bg-01.svg': 'img-05',
-                  '/assets/images/card-bg-02.svg': 'img-06',
-                  '/assets/images/card-bg-03.svg': 'img-07',
-                  '/assets/images/card-bg-04.svg': 'img-08',
-                };
-                
-                return pathToKeyMapping[imgValue] || 'img-01';
-              };
-              
               return (
                 <Card
                   key={study.id}
-                  preset={mapToPresetKey(study.img)}
+                  preset={study.img}
                   id={study.id}
                   nick={study.nick}
                   title={study.name}
                   points={study.point || 0}
                   createdAt={study?.createdAt?.split('T')[0]}
                   description={study.content}
-                  emojiData={study.studyEmojis?.map(item => ({
-                    emoji: item.emoji?.symbol || item.symbol || '🔥',
-                    count: item.count || 0,
-                  })) || []}
+                  emojiData={
+                    study.studyEmojis?.map(item => ({
+                      emoji: item.emoji?.symbol || item.symbol || '🔥',
+                      count: item.count || 0,
+                    })) || []
+                  }
                 />
               );
             })}

--- a/src/styles/components/organisms/Card.module.css
+++ b/src/styles/components/organisms/Card.module.css
@@ -112,3 +112,9 @@
     0 0 0 1px #3b82f6,
     0 6px 20px rgba(59, 130, 246, 0.4);
 }
+
+@media (max-width: 1199px) {
+  .card {
+    max-width: none;
+  }
+}

--- a/src/styles/components/organisms/Header.module.css
+++ b/src/styles/components/organisms/Header.module.css
@@ -17,6 +17,12 @@
   display: flex;
   align-items: center;
   gap: 1.6rem;
+
+  a {
+    display: inline-block;
+    padding: 0.5rem;
+    margin-right: 1.6rem;
+  }
 }
 
 .headerButton {
@@ -29,26 +35,48 @@
   font-size: 1.6rem;
   font-weight: 400;
   color: var(--brand-blue);
-  margin-right: 1.6rem;
+}
+
+/* 데스크탑 이상 */
+@media (max-width: 1600px) {
+  .header {
+    max-width: calc(120rem + 5rem);
+    padding: 2.5rem;
+  }
 }
 
 /* 태블릿 반응형 */
 @media (max-width: 1024px) {
   .header {
-    padding: 2.25rem 4.4rem;
+    padding: 2.5rem;
   }
 }
 
 /* 모바일 반응형 */
 @media (max-width: 743px) {
   .header {
-    padding: 2.25rem 1.6rem;
+    padding: 2rem 1.6rem;
+    margin-bottom: 2rem;
 
     button {
       font-size: 1.4rem;
       padding: 2rem 1.5rem;
       width: auto;
       height: auto;
+    }
+  }
+}
+
+@media (max-width: 575px) {
+  .header {
+    flex-direction: column;
+    gap: 2rem;
+  }
+
+  .headerButtons {
+    gap: 0.6rem;
+    a {
+      margin-right: 0.6rem;
     }
   }
 }

--- a/src/styles/pages/FocusPage.module.css
+++ b/src/styles/pages/FocusPage.module.css
@@ -242,7 +242,7 @@
 @media (max-width: 743px) {
   .focusPage {
     width: calc(100% - 3.2rem);
-    padding: 1.6rem;
+    padding: 3rem 1.6rem;
   }
 
   .mainTime {

--- a/src/styles/pages/StudyPage.module.css
+++ b/src/styles/pages/StudyPage.module.css
@@ -42,7 +42,6 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 2.4rem;
-  min-height: 51rem;
   align-items: flex-start;
 }
 
@@ -50,6 +49,10 @@
   font-size: 2.4rem;
   font-weight: 700;
   margin-bottom: 2.5rem;
+}
+
+.studyPageWrapper:nth-of-type(1) .studyPageTitle:nth-of-type(1) {
+  margin-bottom: 0;
 }
 
 .studyListEmpty {
@@ -72,10 +75,35 @@
     grid-template-columns: repeat(2, 1fr);
     justify-items: center;
   }
+
+  .studyPageContainer {
+    max-width: calc(120rem + 5rem);
+    padding: 0 2.5rem;
+  }
 }
 
 @media (max-width: 820px) {
   .studyList {
     grid-template-columns: repeat(1, 1fr);
+  }
+}
+
+@media (max-width: 743px) {
+  .studyPageContainer {
+    padding: 0 1.6rem;
+  }
+
+  .studyPageWrapper {
+    padding: 2rem 1.6rem;
+  }
+
+  .studyPageTitle {
+    font-size: 2rem;
+    font-weight: 500;
+    letter-spacing: -1px;
+  }
+
+  .studyListFilter {
+    flex-direction: column;
   }
 }

--- a/src/utils/api/study/getStudyApi.js
+++ b/src/utils/api/study/getStudyApi.js
@@ -2,28 +2,15 @@ import { instance } from '../axiosInstance';
 
 const getStudyApi = async (params = {}) => {
   try {
-    const {
-      isActive = true,
-      recentOrder,
-      offset,
-      limit,
-      keyword,
-      pointOrder,
-    } = params;
+    const { isActive = true, offset, limit, keyword, sort } = params;
 
     const queryParams = {
       isActive,
-      recentOrder,
+      sort,
       offset,
       limit,
       keyword,
-      pointOrder,
     };
-
-    // 개발 환경에서만 캐시 무시 파라미터 추가
-    if (import.meta.env.DEV) {
-      queryParams._t = Date.now();
-    }
 
     const response = await instance.get('/api/studies', {
       params: queryParams,


### PR DESCRIPTION
### 반영 브랜치
ex) fix/StudyPage -> develop

### 변경 사항
- [x] Dropdown 컴포넌트에 options prop 추가 (확정성 업)
- [x] StudyPage에서 정렬 로직 개선 및 UI 요소 수정
- [x] Card 및 Header 스타일 업데이트
- [x] FocusPage와 StudyPage의 반응형 디자인 개선

### 테스트 결과
- 포인트 정렬 정상화

### 참고 사항 (Optional)
- 스터디 메인 페이지 -> 000님 환영 누르면 드랍다운 되는 부분은 추후 수정 예정
- 다른 급한 수정부터 진행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 드롭다운이 커스텀 옵션을 지원하도록 개선되었습니다.
  - 스터디 페이지 정렬이 단일 드롭다운으로 통합되었습니다.

- Style
  - 카드: 1199px 이하에서 최대 너비 제한 해제로 가로 공간 활용 향상.
  - 헤더: 링크 간격/패딩 조정, 1600px/575px 등 반응형 브레이크포인트 추가 및 패딩 개선.
  - 포커스 페이지: 작은 화면에서 세로 패딩 확대.
  - 스터디 페이지: 리스트 최소 높이 제거, 제목 간격 조정, 컨테이너/필터 반응형 레이아웃 개선.

- Refactor
  - 앱 부트스트랩 로직을 단순화하고 정렬 파라미터를 일관화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->