### PR TITLE
feat: 로그인 후 로그인 및 회원가입 페이지 접근 시 루트로 이동

### DIFF
--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -8,13 +8,20 @@ import PasswordInput from '../components/molecules/PasswordInput.jsx';
 import { loginSchema } from '../utils/validation/loginSchema.js';
 import styles from '../styles/pages/LoginPage.module.css';
 import { useAuthStore } from '../store/authStore.js';
+import { useEffect } from 'react';
 
 /**
  * 로그인 페이지
  */
 export default function LoginPage() {
   const navigate = useNavigate();
-  const { login } = useAuthStore();
+  const { login, user } = useAuthStore();
+
+  useEffect(() => {
+    if (user) {
+      navigate('/');
+    }
+  }, [user, navigate]);
 
   // 폼 상태 관리
   const {
@@ -23,7 +30,7 @@ export default function LoginPage() {
     formState: { errors, isSubmitting, isValid },
   } = useForm({
     resolver: zodResolver(loginSchema),
-    mode: 'onBlur',
+    mode: 'onChange',
     defaultValues: {
       email: '',
       password: '',
@@ -56,9 +63,7 @@ export default function LoginPage() {
         {/* 헤더 */}
         <div className={styles.header}>
           <h1 className={styles.title}>로그인</h1>
-          <p className={styles.subtitle}>
-            MindMeld에 다시 오신 것을 환영합니다
-          </p>
+          <p className={styles.subtitle}>MindMeld에 오신 것을 환영합니다</p>
         </div>
 
         {/* 이메일 */}

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -27,7 +27,7 @@ export default function ProfilePage() {
     formState: { errors, isSubmitting, isValid },
   } = useForm({
     resolver: zodResolver(profileSchema),
-    mode: 'onBlur',
+    mode: 'onChange',
     defaultValues: {
       username: '',
       nick: '',

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -8,12 +8,22 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { registerSchema } from '../utils/validation/registerSchema.js';
 import { postRegisterApi } from '../utils/api/user/postRegisterApi';
+import { useEffect } from 'react';
+import { useAuthStore } from '../store/authStore.js';
 
 /**
  * 회원가입 페이지
  */
 export default function RegisterPage() {
   const navigate = useNavigate();
+
+  const { user } = useAuthStore();
+
+  useEffect(() => {
+    if (user) {
+      navigate('/');
+    }
+  }, [user, navigate]);
 
   // 폼 상태
   const {
@@ -23,7 +33,7 @@ export default function RegisterPage() {
     formState: { errors, isSubmitting, isValid },
   } = useForm({
     resolver: zodResolver(registerSchema),
-    mode: 'onBlur',
+    mode: 'onChange',
     defaultValues: {
       username: '',
       email: '',

--- a/src/styles/components/organisms/Footer.module.css
+++ b/src/styles/components/organisms/Footer.module.css
@@ -6,3 +6,9 @@ footer {
   padding: 1.6rem;
   margin: 8rem auto;
 }
+
+@media (max-width: 743px) {
+  footer {
+    margin: 4rem auto;
+  }
+}

--- a/src/styles/pages/LoginPage.module.css
+++ b/src/styles/pages/LoginPage.module.css
@@ -3,8 +3,7 @@
 .page {
   display: grid;
   place-items: center center;
-  padding: 2.4rem;
-  min-height: 100vh;
+  padding: 0 2.4rem;
   background: var(--background-primary);
   min-width: 35rem; /* 350px 이하 프리즈 */
 }
@@ -16,7 +15,6 @@
   border-radius: 1.2rem;
   box-shadow: 0 0.4rem 2.4rem rgba(0, 0, 0, 0.08);
   padding: 4rem 3.2rem 3.2rem;
-  margin: 2.4rem 0;
 }
 
 /* 헤더 섹션 */
@@ -49,12 +47,8 @@
 
 /* 섹션 공통 */
 .section {
-  padding-bottom: 1.6rem;
-  margin-bottom: 1.2rem;
-}
-
-.section > * + * {
-  margin-top: 1.2rem;
+  padding-bottom: 0.8rem;
+  margin-bottom: 0.8rem;
 }
 
 /* 라벨 */
@@ -66,15 +60,6 @@
   margin-bottom: 1.2rem;
 }
 
-/* 인풋 통일 규칙 */
-.section :global(input),
-.section :global(textarea),
-.section :global(.wrap) {
-  width: 100%;
-  box-sizing: border-box;
-}
-
-/* CTA 버튼 영역 */
 .cta {
   margin: 3.2rem 0 2.4rem;
   display: flex;
@@ -92,12 +77,6 @@
   transition: all 200ms ease;
   border-radius: 1rem;
   background: linear-gradient(135deg, var(--brand-blue) 0%, #4338ca 100%);
-}
-
-.submitButton:hover:not(:disabled) {
-  background: linear-gradient(135deg, var(--btn-active) 0%, #3730a3 100%);
-  transform: translateY(-0.2rem);
-  box-shadow: 0 0.8rem 2rem rgba(0, 19, 167, 0.2);
 }
 
 .submitButton:disabled {
@@ -195,13 +174,11 @@
 /* 태블릿 반응형 */
 @media (max-width: 1024px) {
   .page {
-    padding: 2rem;
+    padding: 0 2rem;
   }
 
   .card {
-    max-width: 100%;
     padding: 3.2rem 2.4rem;
-    margin: 1.6rem 0;
     border-radius: 1rem;
   }
 
@@ -240,10 +217,6 @@
 
 /* 모바일 반응형 */
 @media (max-width: 743px) {
-  .page {
-    padding: 1.6rem;
-  }
-
   .card {
     padding: 2.4rem 2rem;
     border-radius: 0.8rem;
@@ -346,12 +319,4 @@
   .label {
     color: #fff;
   }
-}
-
-/* 포커스 스타일 강화 */
-.section :global(input:focus),
-.section :global(textarea:focus) {
-  border-color: var(--brand-blue);
-  box-shadow: 0 0 0 0.3rem rgba(0, 19, 167, 0.1);
-  outline: none;
 }

--- a/src/styles/pages/ProfilePage.module.css
+++ b/src/styles/pages/ProfilePage.module.css
@@ -3,8 +3,7 @@
 .page {
   display: grid;
   place-items: start center;
-  padding: 2.4rem;
-  min-height: 100vh;
+  padding: 0 2.4rem;
   background: var(--background-primary);
 }
 
@@ -15,7 +14,6 @@
   border-radius: 1.2rem;
   box-shadow: 0 0.4rem 2.4rem rgba(0, 0, 0, 0.08);
   padding: 3.2rem 2.4rem 2.4rem;
-  margin: 2.4rem 0;
 }
 
 /* 헤더 섹션 */
@@ -52,10 +50,6 @@
   margin-bottom: 0.8rem;
 }
 
-.section > * + * {
-  margin-top: 1.2rem;
-}
-
 /* 라벨 */
 .label {
   display: block;
@@ -63,14 +57,6 @@
   font-weight: 600;
   font-size: 1.6rem;
   margin-bottom: 1.2rem;
-}
-
-/* 인풋 통일 규칙 */
-.section :global(input),
-.section :global(textarea),
-.section :global(.wrap) {
-  width: 100%;
-  box-sizing: border-box;
 }
 
 /* 버튼 그룹 */
@@ -83,7 +69,6 @@
 
 .cancelButton,
 .submitButton {
-  flex: 1;
   height: 5.2rem;
   display: inline-flex;
   align-items: center;
@@ -99,13 +84,6 @@
   color: var(--text-gray);
   border: 0.2rem solid var(--border-gray);
   background: transparent;
-}
-
-.cancelButton:hover:not(:disabled) {
-  border-color: var(--text-gray);
-  color: var(--text-primary);
-  transform: translateY(-0.1rem);
-  box-shadow: 0 0.4rem 0.8rem rgba(0, 0, 0, 0.1);
 }
 
 .submitButton {
@@ -193,19 +171,12 @@
 /* 태블릿 반응형 */
 @media (max-width: 76.8rem) {
   .page {
-    padding: 2rem;
+    padding: 0 2rem;
   }
 
   .card {
-    max-width: 100%;
     padding: 2.4rem 2rem;
-    margin: 1.6rem 0;
     border-radius: 1rem;
-  }
-
-  .header {
-    margin-bottom: 2.4rem;
-    padding-bottom: 1.6rem;
   }
 
   .title {
@@ -242,7 +213,7 @@
 }
 
 /* 모바일 반응형 */
-@media (max-width: 48rem) {
+@media (max-width: 480px) {
   .page {
     padding: 1.2rem;
   }
@@ -250,11 +221,6 @@
   .card {
     padding: 2rem 1.6rem;
     border-radius: 0.8rem;
-  }
-
-  .header {
-    margin-bottom: 2rem;
-    padding-bottom: 1.2rem;
   }
 
   .title {
@@ -266,7 +232,6 @@
   }
 
   .buttonGroup {
-    flex-direction: column;
     margin: 2rem 0 1.2rem;
     gap: 0.8rem;
   }

--- a/src/styles/pages/RegisterPage.module.css
+++ b/src/styles/pages/RegisterPage.module.css
@@ -16,7 +16,6 @@
   border-radius: 1.2rem;
   box-shadow: 0 0.4rem 2.4rem rgba(0, 0, 0, 0.08);
   padding: 3.2rem 2.4rem 2.4rem;
-  margin: 2.4rem 0;
 }
 
 /* 헤더 섹션 */
@@ -62,15 +61,6 @@
   margin-bottom: 1.2rem;
 }
 
-/* 인풋 통일 규칙 */
-.section :global(input),
-.section :global(textarea),
-.section :global(.wrap) {
-  width: 100%;
-  box-sizing: border-box;
-}
-
-/* CTA 버튼 영역 */
 .cta {
   margin: 2.4rem 0 1.6rem;
   display: flex;
@@ -87,12 +77,6 @@
   font-size: 1.8rem;
   font-weight: 600;
   transition: all 120ms ease;
-}
-
-.submitButton:hover:not(:disabled) {
-  background: var(--btn-active);
-  transform: translateY(-0.1rem);
-  box-shadow: 0 0.6rem 1.2rem rgba(0, 19, 167, 0.15);
 }
 
 /* 로그인 링크 */

--- a/src/utils/api/user/postRefreshApi.js
+++ b/src/utils/api/user/postRefreshApi.js
@@ -2,9 +2,7 @@ import { instance } from '../axiosInstance.js';
 
 export const postRefreshApi = async () => {
   try {
-    const response = await instance.post('/api/users/refresh', null, {
-      headers: { Authorization: null },
-    });
+    const response = await instance.post('/api/users/refresh');
 
     // 응답 데이터 구조 안전하게 접근
     const responseData = response.data?.data || response.data;


### PR DESCRIPTION
### 반영 브랜치
ex) fix/auth -> develop

### 변경 사항
- [x] 로그인, 회원가입, 프로필 페이지의 폼 유효성 검사 모드 변경
- [x] 사용자 로그인 상태에 따른 리디렉션 추가
- [x] Footer 및 페이지 스타일 수정으로 반응형 디자인 개선

### 테스트 결과
- 로그인한 유저가 로그인, 회원가입 페이지 접근 시 루트로 강제 이동됨.
- 폼 입력할 때 onBlur에서 onChange 이벤트로 변경

### 참고 사항 (Optional)
- 에러 추가적으로 잡기 진행
- 헤더 부분 모바일 일 땐 드랍다운으로 설정해야 됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 로그인/회원가입 페이지에서 이미 로그인된 경우 자동으로 홈으로 이동합니다.
  - 로그인·회원가입·프로필 폼 검증이 입력 즉시(onChange) 반영되어 오류를 빠르게 확인할 수 있습니다.
- Style
  - 로그인·프로필·회원가입 페이지 전반의 여백을 조정해 화면 밀도를 높였습니다.
  - 버튼 호버 효과 일부를 간소화하고 입력 포커스·글로벌 입력 스타일을 정리했습니다.
  - 프로필 모바일 레이아웃과 타이포를 최적화했습니다.
  - 푸터가 작은 화면(≤743px)에서 세로 여백이 축소되어 가시성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->