### PR TITLE
Feat: study password modal enhancements

### DIFF
--- a/src/components/atoms/DynamicStudyTitle.jsx
+++ b/src/components/atoms/DynamicStudyTitle.jsx
@@ -73,7 +73,6 @@ export default function DynamicStudyTitle({
               style={{
                 color: 'var(--black-black_414141, #414141)',
                 display: 'inline-block',
-                marginLeft: '0.5rem',
                 marginRight: '0.5rem',
               }}
             >

--- a/src/components/molecules/StudyPoints.jsx
+++ b/src/components/molecules/StudyPoints.jsx
@@ -6,6 +6,9 @@ import styles from '../../styles/components/molecules/StudyPoints.module.css';
  * @param {number} points - 획득한 포인트
  */
 export default function StudyPoints({ points = 0 }) {
+  console.log('StudyPoints - received points:', points);
+  console.log('StudyPoints - points type:', typeof points);
+
   return (
     <div className={styles.container}>
       <p className={styles.label}>현재까지 획득한 포인트</p>

--- a/src/components/organisms/StudyPasswordModal.jsx
+++ b/src/components/organisms/StudyPasswordModal.jsx
@@ -42,6 +42,16 @@ export default function StudyPasswordModal({
   //   return () => window.removeEventListener('keydown', onKeyDown);
   // }, [isOpen, onClose]);
 
+  // 모달 열릴 때 body 스크롤 락
+  useEffect(() => {
+    if (!isOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   const handleSubmit = async e => {
@@ -86,6 +96,7 @@ export default function StudyPasswordModal({
         aria-describedby="studyPasswordDesc"
       >
         <DynamicStudyTitle
+          id="studyPasswordTitle"
           nickname={nickname}
           studyName={studyName}
           backgroundImage={backgroundImage}
@@ -113,6 +124,7 @@ export default function StudyPasswordModal({
               onSubmit={handleSubmit}
               placeholder="비밀번호를 입력해 주세요"
               disabled={submitting}
+              autoFocus
             />
 
             <div className={styles.actions}>
@@ -134,7 +146,7 @@ export default function StudyPasswordModal({
           </form>
 
           {/* PC: 우상단 absolute / 모바일: 버튼 아래 중앙 (CSS에서 분기) */}
-          <button className={styles.exit} onClick={onClose}>
+          <button type="button" className={styles.exit} onClick={onClose}>
             나가기
           </button>
         </div>

--- a/src/components/organisms/StudyPasswordModal.jsx
+++ b/src/components/organisms/StudyPasswordModal.jsx
@@ -32,15 +32,15 @@ export default function StudyPasswordModal({
     }
   }, [isOpen]);
 
-  // Esc로 닫기 (접근성)
-  useEffect(() => {
-    if (!isOpen) return;
-    const onKeyDown = e => {
-      if (e.key === 'Escape') onClose?.();
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [isOpen, onClose]);
+  // Esc로 닫기 비활성화 (나가기 버튼으로만 닫기)
+  // useEffect(() => {
+  //   if (!isOpen) return;
+  //   const onKeyDown = e => {
+  //     if (e.key === 'Escape') onClose?.();
+  //   };
+  //   window.addEventListener('keydown', onKeyDown);
+  //   return () => window.removeEventListener('keydown', onKeyDown);
+  // }, [isOpen, onClose]);
 
   if (!isOpen) return null;
 
@@ -77,10 +77,9 @@ export default function StudyPasswordModal({
   };
 
   return createPortal(
-    <div className={styles.modalBackdrop} onClick={onClose}>
+    <div className={styles.modalBackdrop}>
       <div
         className={styles.modal}
-        onClick={e => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
         aria-labelledby="studyPasswordTitle"

--- a/src/pages/FocusPage.jsx
+++ b/src/pages/FocusPage.jsx
@@ -64,8 +64,13 @@ export default function FocusPage() {
 
   // 비밀번호 검증 핸들러
   const handlePasswordVerify = async password => {
+    console.log('FocusPage: 비밀번호 검증 시작', {
+      id,
+      password: password ? '***' : 'empty',
+    });
     try {
       const isValid = await verifyStudyPassword(id, password);
+      console.log('FocusPage: 비밀번호 검증 결과', { isValid });
       if (isValid) {
         setIsPasswordModalOpen(false);
         // 비밀번호 검증 성공 시 HabitPage로 이동 (비밀번호를 state로 전달)
@@ -79,7 +84,7 @@ export default function FocusPage() {
       }
       return false;
     } catch (error) {
-      console.error('비밀번호 검증 실패:', error);
+      console.error('FocusPage: 비밀번호 검증 실패:', error);
       // 네트워크 오류는 예외를 다시 throw하여 모달에서 처리하도록 함
       throw error;
     }

--- a/src/pages/FocusPage.jsx
+++ b/src/pages/FocusPage.jsx
@@ -69,14 +69,15 @@ export default function FocusPage() {
       password: password ? '***' : 'empty',
     });
     try {
-      const isValid = await verifyStudyPassword(id, password);
+      const isValid = await verifyStudyPassword(id, password, {
+        timeout: 10000,
+      });
       console.log('FocusPage: 비밀번호 검증 결과', { isValid });
       if (isValid) {
         setIsPasswordModalOpen(false);
-        // 비밀번호 검증 성공 시 HabitPage로 이동 (비밀번호를 state로 전달)
+        // 비밀번호 검증 성공 시 HabitPage로 이동 (보안상 비밀번호는 전달하지 않음)
         navigate(`/habit/${id}`, {
           state: {
-            verifiedPassword: password,
             studyData: focusData,
           },
         });

--- a/src/pages/StudyDetailPage.jsx
+++ b/src/pages/StudyDetailPage.jsx
@@ -35,8 +35,21 @@ const getStudyBackground = studyData =>
   getStudyField(studyData, 'background') ||
   getStudyField(studyData, 'backgroundImage', '');
 
-const getStudyPoints = studyData =>
-  studyData?.pointsSum || studyData?._count?.points || studyData?.points || 0;
+const getStudyPoints = studyData => {
+  console.log('getStudyPoints - studyData:', studyData);
+  console.log('getStudyPoints - studyData.point:', studyData?.point);
+  console.log('getStudyPoints - studyData.points:', studyData?.points);
+  console.log('getStudyPoints - studyData.pointsSum:', studyData?.pointsSum);
+
+  const result =
+    studyData?.point ||
+    studyData?.points ||
+    studyData?.pointsSum ||
+    studyData?._count?.points ||
+    0;
+  console.log('getStudyPoints - final result:', result);
+  return result;
+};
 
 export default function StudyDetailPage() {
   const { id } = useParams();
@@ -317,6 +330,11 @@ export default function StudyDetailPage() {
         </div>
 
         <div className={styles.pointsSection}>
+          {console.log('StudyDetailPage - studyData:', studyData)}
+          {console.log(
+            'StudyDetailPage - getStudyPoints result:',
+            getStudyPoints(studyData),
+          )}
           <StudyPoints points={getStudyPoints(studyData)} />
         </div>
       </div>

--- a/src/pages/StudyDetailPage.jsx
+++ b/src/pages/StudyDetailPage.jsx
@@ -36,19 +36,13 @@ const getStudyBackground = studyData =>
   getStudyField(studyData, 'backgroundImage', '');
 
 const getStudyPoints = studyData => {
-  console.log('getStudyPoints - studyData:', studyData);
-  console.log('getStudyPoints - studyData.point:', studyData?.point);
-  console.log('getStudyPoints - studyData.points:', studyData?.points);
-  console.log('getStudyPoints - studyData.pointsSum:', studyData?.pointsSum);
-
   const result =
-    studyData?.point ||
-    studyData?.points ||
-    studyData?.pointsSum ||
-    studyData?._count?.points ||
+    studyData?.point ??
+    studyData?.points ??
+    studyData?.pointsSum ??
+    studyData?._count?.points ??
     0;
-  console.log('getStudyPoints - final result:', result);
-  return result;
+  return typeof result === 'number' ? result : Number(result) || 0;
 };
 
 export default function StudyDetailPage() {
@@ -190,14 +184,15 @@ export default function StudyDetailPage() {
       password: password ? '***' : 'empty',
     });
     try {
-      const isValid = await verifyStudyPassword(id, password);
+      const isValid = await verifyStudyPassword(id, password, {
+        timeout: 10000,
+      });
       console.log('StudyDetailPage: 비밀번호 검증 결과', { isValid });
       if (isValid) {
         setIsPasswordModalOpen(false);
-        // 비밀번호 검증 성공 시 HabitPage로 이동 (비밀번호를 state로 전달)
+        // 비밀번호 검증 성공 시 HabitPage로 이동 (보안상 비밀번호는 전달하지 않음)
         navigate(`/habit/${id}`, {
           state: {
-            verifiedPassword: password,
             studyData: studyData,
           },
         });
@@ -335,11 +330,6 @@ export default function StudyDetailPage() {
         </div>
 
         <div className={styles.pointsSection}>
-          {console.log('StudyDetailPage - studyData:', studyData)}
-          {console.log(
-            'StudyDetailPage - getStudyPoints result:',
-            getStudyPoints(studyData),
-          )}
           <StudyPoints points={getStudyPoints(studyData)} />
         </div>
       </div>

--- a/src/pages/StudyDetailPage.jsx
+++ b/src/pages/StudyDetailPage.jsx
@@ -185,8 +185,13 @@ export default function StudyDetailPage() {
 
   // 비밀번호 검증 핸들러
   const handlePasswordVerify = async password => {
+    console.log('StudyDetailPage: 비밀번호 검증 시작', {
+      id,
+      password: password ? '***' : 'empty',
+    });
     try {
       const isValid = await verifyStudyPassword(id, password);
+      console.log('StudyDetailPage: 비밀번호 검증 결과', { isValid });
       if (isValid) {
         setIsPasswordModalOpen(false);
         // 비밀번호 검증 성공 시 HabitPage로 이동 (비밀번호를 state로 전달)
@@ -200,7 +205,7 @@ export default function StudyDetailPage() {
       }
       return false;
     } catch (error) {
-      console.error('비밀번호 검증 실패:', error);
+      console.error('StudyDetailPage: 비밀번호 검증 실패:', error);
       // 네트워크 오류는 예외를 다시 throw하여 모달에서 처리하도록 함
       throw error;
     }

--- a/src/styles/components/atoms/Chip.module.css
+++ b/src/styles/components/atoms/Chip.module.css
@@ -10,7 +10,7 @@
   box-sizing: border-box;
 
   border: none;
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   line-height: 1;
   cursor: pointer;
   user-select: none;
@@ -56,7 +56,7 @@
 }
 
 .label {
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/styles/components/atoms/NavigationButton.module.css
+++ b/src/styles/components/atoms/NavigationButton.module.css
@@ -7,7 +7,7 @@
   font-weight: 500;
   padding: 1.6rem 1.6rem 1.6rem 2.4rem;
   background-color: var(--background-secondary);
-  border-radius: 1.5rem;
+  border-radius: 0.5rem;
   border: 1px solid var(--border-gray);
   cursor: pointer;
 }

--- a/src/styles/components/organisms/HabitRecordTable.module.css
+++ b/src/styles/components/organisms/HabitRecordTable.module.css
@@ -48,7 +48,7 @@
 
   .frame {
     width: 100%; /* 모바일: 페이지 너비에 맞춤 */
-    max-width: 31.2rem; /* 최대 너비 제한 */
+    max-width: 35.2rem; /* 최대 너비 제한 */
     min-width: 0; /* base의 min-width:35rem 무력화 */
     overflow-x: auto; /* 모바일에서 가로 스크롤 활성화 */
     padding: 2.4rem 1.5rem 2.4rem 1.6rem; /* 모바일: 위 2.4rem, 우 1.5rem, 아래 2.4rem, 좌 1.6rem */

--- a/src/styles/pages/FocusPage.module.css
+++ b/src/styles/pages/FocusPage.module.css
@@ -29,6 +29,16 @@
   margin: 0;
 }
 
+.studyTitle {
+  font-size: 3.2rem;
+  font-weight: 700;
+  color: var(--text-primary, #222);
+  margin: 0;
+  line-height: 1.2;
+  display: flex;
+  align-items: baseline;
+}
+
 .nav {
   display: flex;
   gap: 1rem;

--- a/src/styles/pages/HabitPage.module.css
+++ b/src/styles/pages/HabitPage.module.css
@@ -437,6 +437,7 @@
 
   .todayButtons a[href*='/focus/'] {
     font-size: 0;
+    gap: 0.5rem;
   }
 
   .todayButtons a[href*='/study/']::before {
@@ -448,6 +449,7 @@
 
   .todayButtons a[href*='/study/'] {
     font-size: 0;
+    gap: 0.5rem;
   }
 
   /* 홈 버튼 글씨 크기 조정 */
@@ -462,7 +464,7 @@
   }
 
   .cardHeader {
-    font-size: 1.6rem;
+    font-size: 1.8rem;
     margin-bottom: 3.9rem;
   }
 

--- a/src/styles/pages/HabitPage.module.css
+++ b/src/styles/pages/HabitPage.module.css
@@ -10,6 +10,9 @@
   margin: 0 auto;
   box-sizing: border-box;
   gap: 1.2rem;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 /* 제목 + 네비게이션 버튼 (같은 row) */
@@ -39,6 +42,11 @@
 .todayButtons {
   display: flex;
   gap: 1.2rem;
+}
+
+/* PC에서 홈 버튼 글씨 크기 */
+.todayButtons a[href='/'] {
+  font-size: 1.6rem;
 }
 
 /* 현재 시간 섹션 */
@@ -398,13 +406,17 @@
   }
 
   .cardHeader {
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 2.4rem;
+    position: relative;
   }
 
   .cardHeader h2 {
-    /* 모바일에서도 전체 너비 사용 */
-    width: auto;
+    margin: 0;
+    flex: 1;
+    text-align: center;
   }
 
   /* 네비게이션 버튼 - 왼쪽 정렬 */
@@ -415,6 +427,34 @@
     justify-content: flex-start;
   }
 
+  /* 모바일에서 네비게이션 버튼 텍스트 줄이기 */
+  .todayButtons a[href*='/focus/']::before {
+    content: '집중';
+    font-size: 1.4rem;
+    font-weight: 500;
+    margin-right: 0.4rem;
+  }
+
+  .todayButtons a[href*='/focus/'] {
+    font-size: 0;
+  }
+
+  .todayButtons a[href*='/study/']::before {
+    content: '스터디';
+    font-size: 1.4rem;
+    font-weight: 500;
+    margin-right: 0.4rem;
+  }
+
+  .todayButtons a[href*='/study/'] {
+    font-size: 0;
+  }
+
+  /* 홈 버튼 글씨 크기 조정 */
+  .todayButtons a[href='/'] {
+    font-size: 1.4rem;
+  }
+
   .mainCard {
     padding: 2rem 1.6rem;
     width: 31.2rem;
@@ -422,7 +462,7 @@
   }
 
   .cardHeader {
-    font-size: 1.8rem;
+    font-size: 1.6rem;
     margin-bottom: 3.9rem;
   }
 

--- a/src/styles/pages/StudyDetailPage.module.css
+++ b/src/styles/pages/StudyDetailPage.module.css
@@ -10,6 +10,9 @@
   margin: 0 auto;
   box-sizing: border-box;
   gap: 1.2rem;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 /* 로딩 및 에러 상태 */
@@ -95,6 +98,9 @@
 /* 습관 기록표 섹션 */
 .habitTableSection {
   width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 /* 태블릿 반응형 */

--- a/src/utils/api/study/studyPasswordApi.js
+++ b/src/utils/api/study/studyPasswordApi.js
@@ -24,19 +24,19 @@ export async function verifyStudyPassword(studyId, password, options = {}) {
   });
 
   try {
-    // x-study-password 헤더를 사용한 GET 요청으로 비밀번호 검증 시도
-    const { data } = await instance.get(`/api/studies/${id}`, {
-      headers: {
-        'x-study-password': password,
-      },
+    // 백엔드의 전용 비밀번호 검증 API 사용
+    const { data } = await instance.post(`/api/studies/${id}/verify-password`, {
+      password,
+    }, {
       signal: options.signal,
       timeout: options.timeout,
     });
 
-    console.log('studyPasswordApi: 비밀번호 검증 성공 (헤더)', {
-      hasData: !!data,
+    console.log('studyPasswordApi: 비밀번호 검증 성공', {
+      isPasswordValid: data?.isPasswordValid,
     });
-    return true;
+    
+    return data?.isPasswordValid === true;
   } catch (err) {
     console.error('studyPasswordApi: 비밀번호 검증 실패', {
       message: err.message,
@@ -46,16 +46,9 @@ export async function verifyStudyPassword(studyId, password, options = {}) {
       data: err.response?.data,
     });
 
-    // 401, 403 등의 인증 오류는 비밀번호가 틀린 것
-    if (err?.response?.status === 401 || err?.response?.status === 403) {
-      console.log('studyPasswordApi: 인증 오류 - 비밀번호 불일치');
-      return false;
-    }
-    // 400 에러는 잘못된 요청 (비밀번호 불일치 포함)
+    // 400 에러는 비밀번호 누락 또는 잘못된 요청
     if (err?.response?.status === 400) {
-      console.log(
-        'studyPasswordApi: 400 오류 - 비밀번호 불일치 또는 잘못된 요청',
-      );
+      console.log('studyPasswordApi: 400 오류 - 비밀번호 누락 또는 잘못된 요청');
       return false;
     }
     // 404 에러는 스터디가 존재하지 않음

--- a/src/utils/ui/getNicknameColor.js
+++ b/src/utils/ui/getNicknameColor.js
@@ -9,6 +9,23 @@ export function getNicknameColor(backgroundImage) {
     return 'var(--brand-blue, #0013A7)';
   }
 
+  // CSS 변수 형태 처리 (우선순위 높음)
+  if (backgroundImage.includes('--card-mintblue')) {
+    return 'var(--text-mint, #418099)'; // Mint Blue
+  }
+  if (backgroundImage.includes('--card-green')) {
+    return 'var(--text-forest, #2F5233)'; // Green
+  }
+  if (backgroundImage.includes('--card-forest')) {
+    return 'var(--text-forest, #2F5233)'; // Forest
+  }
+  if (backgroundImage.includes('--card-ocean')) {
+    return 'var(--text-ocean, #1A365D)'; // Ocean
+  }
+  if (backgroundImage.includes('--card-blue')) {
+    return 'var(--brand-blue, #0013A7)'; // Blue
+  }
+
   // 백엔드 실제 저장 형식에 맞게 매핑
   if (
     backgroundImage.includes('/img/img-01') ||
@@ -74,6 +91,23 @@ export function getNicknameColor(backgroundImage) {
 export function getNicknameColorClass(backgroundImage) {
   if (!backgroundImage) {
     return 'nickname-blue';
+  }
+
+  // CSS 변수 형태 처리 (우선순위 높음)
+  if (backgroundImage.includes('--card-mintblue')) {
+    return 'nickname-mint'; // Mint Blue
+  }
+  if (backgroundImage.includes('--card-green')) {
+    return 'nickname-forest'; // Green
+  }
+  if (backgroundImage.includes('--card-forest')) {
+    return 'nickname-forest'; // Forest
+  }
+  if (backgroundImage.includes('--card-ocean')) {
+    return 'nickname-ocean'; // Ocean
+  }
+  if (backgroundImage.includes('--card-blue')) {
+    return 'nickname-blue'; // Blue
   }
 
   // 백엔드 실제 저장 형식에 맞게 매핑


### PR DESCRIPTION
### 반영 브랜치
feat/study-password-modal-enhancements -> develop

### 변경 사항
- [x] 백엔드 전용 비밀번호 검증 API 사용 (POST /api/studies/{id}/verify-password)
- [x] StudyPasswordModal UX 개선: 나가기 버튼으로만 닫기 가능, Esc 키 및 배경 클릭 비활성화
- [x] DynamicStudyTitle 배경 컬러별 닉네임 색상 매핑 추가 (--card-green, --card-mintblue 등)
- [x] FocusPage에 StudyDetailPage와 동일한 비밀번호 모달 및 검증 기능 추가
- [x] FocusPage에 DynamicStudyTitle 및 StudyPoints 컴포넌트 적용
- [x] HabitPage 모바일 네비게이션 버튼 라벨 단축 ("집중", "스터디")
- [x] HabitPage, StudyDetailPage .page 컨테이너 좌우 중앙 정렬 적용
- [x] 습관 기록표 모바일 max-width 35.2rem으로 확장
- [x] Chip 컴포넌트 폰트 크기 1.4rem으로 조정
- [x] DynamicStudyTitle 닉네임과 "의" 사이 마진 제거
- [x] 비밀번호 검증 과정 디버깅 로그 추가

### 테스트 결과
- PC/태블릿/모바일 모든 브레이크포인트에서 레이아웃 정상 동작 확인
- 비밀번호 검증 API 정상 동작 확인 (올바른/틀린 비밀번호 테스트)
- StudyPasswordModal 나가기 버튼으로만 닫기 동작 확인
- DynamicStudyTitle 배경별 닉네임 색상 변경 확인
- FocusPage와 StudyDetailPage 비밀번호 모달 일관성 확인

### 참고 사항 (Optional)
- 비밀번호 검증은 백엔드의 전용 API 엔드포인트를 사용하여 보안성 향상
- 모달 UX 개선으로 사용자 실수로 인한 모달 닫기 방지
- CSS 변수 형태 배경 처리로 다양한 배경 타입 지원
- 반응형 UI 개선으로 모바일 사용성 향상


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - “오늘의 습관” 실행 시 비밀번호 입력 모달로 인증 후 이동하도록 변경; 포인트 표시가 컴포넌트로 대체되고 제목이 동적 타이틀로 렌더링됩니다.

- Bug Fixes
  - 포인트 우선순위 보정으로 더 정확한 점수 표시
  - 비밀번호 검증 흐름 및 실패 처리 개선, 서버 응답에 따른 검증 결과 반영

- Style
  - Chip 글자 크기 축소 및 네비게이션 버튼 모서리 축소
  - Habit/Study 페이지 레이아웃 중앙 정렬 및 모바일 가독성 개선
  - 집중 페이지 제목 스타일 조정 및 한글 입자 간격 축소
  - 모바일 습관 기록 표 너비 확대

- Accessibility / UX
  - 비밀번호 모달에 입력 자동포커스, 바디 스크롤 잠금, 닫기 동작 조정(백드롭·Esc 비활성화), 제목 연결 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->