### PR TITLE
hotfix: API 엔드포인트를 온라인 배포 서버로 변경

### DIFF
--- a/src/utils/api/axiosInstance.js
+++ b/src/utils/api/axiosInstance.js
@@ -1,9 +1,8 @@
 import axios from 'axios';
 
 export const instance = axios.create({
-
   baseURL:
-    import.meta.env.VITE_API_TEST_URL ||
+    import.meta.env.VITE_API_BASE_URL ||
     'https://eight-studyforest-team2-be.onrender.com',
 
   withCredentials: true,

--- a/src/utils/api/axiosInstance.js
+++ b/src/utils/api/axiosInstance.js
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
 export const instance = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
+  baseURL:
+    import.meta.env.VITE_API_TEST_URL ||
+    'https://eight-studyforest-team2-be.onrender.com',
   withCredentials: true,
   timeout: 5000,
 });

--- a/src/utils/api/axiosInstance.js
+++ b/src/utils/api/axiosInstance.js
@@ -1,9 +1,10 @@
 import axios from 'axios';
 
 export const instance = axios.create({
-  baseURL:
+  baseURL: 
     import.meta.env.VITE_API_BASE_URL ||
-    'https://eight-studyforest-team2-be.onrender.com',
+    import.meta.env.VITE_API_TEST_URL ||
+    'https://eight-studyforest-team2-be.onrender.com'
 
   withCredentials: true,
   timeout: 5000,


### PR DESCRIPTION
- localhost:3000 → https://eight-studyforest-team2-be.onrender.com
- VITE_API_TEST_URL 환경변수 사용
- 폴백으로 직접 URL 설정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - 일부 배포/개발 환경에서 API 기본 주소 미설정으로 발생하던 요청 실패 문제를 해결했습니다. 환경 변수가 비어 있어도 기본 백엔드 주소로 대체되어 네트워크 오류가 감소합니다.

- Chores
  - API 통신 기본값을 정비해 예측 가능한 동작을 보장했습니다. 쿠키 기반 인증 유지 및 요청 타임아웃 등 기존 동작은 변경 없이 그대로 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->