### PR TITLE
feat: improve card header spacing on habit page

### DIFF
--- a/src/styles/pages/HabitPage.module.css
+++ b/src/styles/pages/HabitPage.module.css
@@ -42,6 +42,7 @@
 .todayButtons {
   display: flex;
   gap: 1.2rem;
+  align-content: flex-start;
 }
 
 /* PC에서 홈 버튼 글씨 크기 */

--- a/src/styles/pages/HabitPage.module.css
+++ b/src/styles/pages/HabitPage.module.css
@@ -87,6 +87,8 @@
   align-items: center;
   font-size: 2.4rem;
   position: relative;
+  margin-top: 1rem;
+  margin-bottom: 2rem;
 }
 
 .cardHeader h2 {
@@ -465,6 +467,7 @@
 
   .cardHeader {
     font-size: 1.8rem;
+    margin-top: 1rem;
     margin-bottom: 3.9rem;
   }
 

--- a/src/styles/pages/StudyDetailPage.module.css
+++ b/src/styles/pages/StudyDetailPage.module.css
@@ -86,6 +86,7 @@
   gap: 1.2rem;
   flex-shrink: 0; /* 버튼 영역이 축소되지 않도록 */
   align-items: flex-start;
+  align-content: flex-start;
 }
 
 /* 하단 섹션: 소개 + 포인트 */


### PR DESCRIPTION
- Add margin-top: 1rem and margin-bottom: 2rem for PC/tablet
- Add margin-top: 1rem and keep margin-bottom: 3.9rem for mobile
- Better visual spacing between card header and content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 스타일
  * 습관 페이지 카드 헤더의 세로 여백을 조정했습니다(기본 화면 상단 1rem·하단 2rem, 모바일 상단 1rem 유지된 하단).
  * 습관 및 스터디 상세 페이지의 오늘 버튼 정렬을 왼쪽 상단 정렬로 조정하여 버튼 그룹의 배치 일관성을 개선했습니다.
  * 레이아웃 개선으로 가독성 및 시각적 균형이 향상되며 기능적 동작에는 영향이 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->