### PR TITLE
Hotfix/toast fix

### DIFF
--- a/src/components/atoms/Toast.jsx
+++ b/src/components/atoms/Toast.jsx
@@ -7,7 +7,7 @@ export default function Toast({
   message = '',
 }) {
   const messageMap = {
-    error: '집중이 중단되었습니다.',
+    error: '비밀번호가 일치하지 않습니다. 다시 입력해주세요.',
     mismatch: '비밀번호가 일치하지 않습니다. 다시 입력해주세요.',
     point: `${point}포인트를 획득했습니다!`,
     basic: message,

--- a/src/components/organisms/StudyActions.jsx
+++ b/src/components/organisms/StudyActions.jsx
@@ -114,7 +114,7 @@ export default function StudyActions({
         statusText: error.response?.statusText,
         data: error.response?.data,
       });
-      return false; // false 반환 → StudyPasswordModal에서 네트워크 에러 토스트 표시, 모달 유지
+      return false; // false 반환 → StudyPasswordModal에서 mismatch 토스트 표시
     }
   };
 
@@ -163,7 +163,7 @@ export default function StudyActions({
       }
     } catch (error) {
       console.error('비밀번호 검증 실패:', error);
-      return false;
+      return false; // false 반환 → StudyPasswordModal에서 mismatch 토스트 표시
     }
   };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 비밀번호 불일치 상황에서 표시되는 토스트 메시지를 “비밀번호가 일치하지 않습니다. 다시 입력해주세요.”로 업데이트하여 안내 문구를 명확화했습니다. 아이콘, 유형, 접근성 속성 등 기존 동작은 변경되지 않았습니다.
* **Chores**
  * 내부 주석에서 네트워크 오류 관련 표현을 비밀번호 불일치 토스트로 정정했습니다. 앱 기능이나 동작에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->